### PR TITLE
Refactor logger to create logging directory if not exist

### DIFF
--- a/output_generators/logger.py
+++ b/output_generators/logger.py
@@ -1,5 +1,6 @@
 """Logger implemented here. Other methods call this one when writing messages to log to have a single logger."""
 
+import os
 import logging
 from datetime import date, datetime
 
@@ -7,8 +8,11 @@ log_level = "DEBUG"
 
 numeric_level = getattr(logging, log_level.upper(), 10)
 LOG_FORMAT = "%(levelname)s %(asctime)s - %(message)s"
+LOG_PATH = "./output/logs/"
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+
 #filename = "./output/logs/test.log"
-file = "./output/logs/" + date.today().strftime("%b-%d-%Y") + "--" + datetime.now().strftime("%H-%M-%S") + ".log"
+file = LOG_PATH + date.today().strftime("%b-%d-%Y") + "--" + datetime.now().strftime("%H-%M-%S") + ".log"
 logger = logging.getLogger("tool")
 logging.basicConfig(filename = file, level = numeric_level, format = LOG_FORMAT)
 


### PR DESCRIPTION
This PR refactors `logger.py` to create the directory in which log files shall be stored before the logger creates log files.

Initial problem: The logger does not create the output directories by itself, which causes a `FileNotFoundError` exception:

`FileNotFoundError: [Errno 2] No such file or directory: '/.../code2DFD/output/logs/Nov-13-2023--16-11-59.log'`

Tested with Python 3.10.12 on macOS with Apple Silicon architecture.