### PR TITLE
Fix: output generation

### DIFF
--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -1,7 +1,7 @@
 import ast
+import os
 from datetime import datetime
 
-#import output_generators.calculate_metrics as calculate_metrics
 import output_generators.codeable_model as codeable_model
 import core.technology_switch as tech_sw
 import tmp.tmp as tmp
@@ -105,47 +105,39 @@ def perform_analysis():
     microservices, information_flows, external_components = merge_duplicate_annotations(microservices, information_flows, external_components)
 
     # Printing
-    print("\nFinished extraction. Results:\n")
+    print("\nFinished extraction")
     repo_path = repo_path.replace("/", "_")
     filename = "./output/results/" + repo_path + ".txt"
-    filename_dict = "./output/results/dict_" + repo_path + ".txt"
-    output_file = open(filename, "w")
-    output_file_dict = open(filename_dict, "w")
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    with open(filename, "w") as output_file:
+        if information_flows:
+            output_file.write("\nInformation Flows:\n")
+            for i in information_flows.keys():
+                output_file.write("\n" + str(information_flows[i]))
 
-    # if information_flows:
-    #     print("\nInformation Flows:")
-    #     output_file.write("\n\nInformation Flows:\n")
-    #     for i in information_flows.keys():
-    #         print("\t", information_flows[i])
-    #         output_file.write("\n" + str(information_flows[i]))
+        if microservices:
+            output_file.write("\nMicroservices:\n")
+            for m in microservices.keys():
+                microservices[m].pop("image", None)
+                microservices[m].pop("pom_path", None)
+                microservices[m].pop("properties", None)
+                output_file.write("\n" + str(microservices[m]))
 
-    # if microservices:
-    #     print("\nMicroservices:")
-    #     output_file.write("\n\nMicroservices:\n")
-    #     for m in microservices.keys():
-    #         print("\t", microservices[m])
-    #         microservices[m].pop("image", None)
-    #         microservices[m].pop("pom_path", None)
-    #         microservices[m].pop("properties", None)
-    #         output_file.write("\n" + str(microservices[m]))
-
-    # if external_components:
-    #     print("\nExternal Components:")
-    #     output_file.write("\n\nExternal Components:\n")
-    #     for e in external_components.keys():
-    #         print("\t", external_components[e])
-    #         output_file.write("\n" + str(external_components[e]))
+        if external_components:
+            output_file.write("\nExternal Components:\n")
+            for e in external_components.keys():
+                output_file.write("\n" + str(external_components[e]))
 
     # Writing dict for calculating metrics
-    complete = dict()
-    complete["microservices"] = microservices
-    complete["information_flows"] = information_flows
-    complete["external_components"] = external_components
+    filename_dict = "./output/results/" + repo_path + "_dict.txt"
+    os.makedirs(os.path.dirname(filename_dict), exist_ok=True)
+    with open(filename_dict, "w") as output_file_dict:
+        complete = dict()
+        complete["microservices"] = microservices
+        complete["information_flows"] = information_flows
+        complete["external_components"] = external_components
 
-    output_file_dict.write(str(complete))
-
-    output_file_dict.close()
-    output_file.close()
+        output_file_dict.write(str(complete))
 
     # Saving
     tmp.tmp_config.set("DFD", "microservices", str(microservices))
@@ -154,8 +146,8 @@ def perform_analysis():
 
     codeable_models, codeable_models_path = codeable_model.output_codeable_model(microservices, information_flows, external_components)
     traceability_content = traceability.output_traceability()
-    visualizer.output_png(codeable_models_path, repo_path)
-    json_architecture.generate_json_architecture(microservices, information_flows, external_components)
+    visualizer.output_png(codeable_models_path)
+    json_architecture.generate_json_architecture(information_flows)
 
     #calculate_metrics.calculate_single_system(repo_path)
 

--- a/output_generators/codeable_model.py
+++ b/output_generators/codeable_model.py
@@ -1,7 +1,7 @@
+import os
+
 import tmp.tmp as tmp
 
-plantuml_path = "plantuml.jar"
-output_directory = "output/codeable_models"
 
 # the used metamodel is microservice_dfds_metamodel.py
 
@@ -116,7 +116,6 @@ def output_codeable_model(microservices, information_flows, external_components)
             new_line = "\nadd_links({" + sender + ": " + receiver + "})"
         file_content += new_line
 
-
     file_content += footer(last_node)
 
     output_path = str()
@@ -130,9 +129,9 @@ def create_file(model_name: str, content: str):
 
     model_name = model_name.replace("-", "_")
     file_path = "./output/codeable_models/" + model_name + ".py"
-    file = open(file_path, "w")
-    file.write(content)
-    file.close()
+    os.makedirs(os.path.dirname(file_path), exist_ok=True)
+    with open(file_path, "w") as file:
+        file.write(content)
 
     return file_path
 

--- a/output_generators/codeable_models_to_plantuml.py
+++ b/output_generators/codeable_models_to_plantuml.py
@@ -1,7 +1,10 @@
+import os.path
+
 import tmp.tmp as tmp
 
 
 plantuml_new = str()
+
 
 def convert(codeable_models_path: str) -> str:
     """Creates (good looking) PlantUML file out of CodeableModels file.
@@ -201,6 +204,7 @@ def write_output(output_file_path):
 
     global plantuml_new
 
+    os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
     with open(output_file_path, 'w+') as output_file:
         output_file.write(plantuml_new)
 

--- a/output_generators/json_architecture.py
+++ b/output_generators/json_architecture.py
@@ -1,10 +1,10 @@
 import json
+import os
 
 import tmp.tmp as tmp
 
 
-
-def generate_json_architecture(microservices: dict, information_flows: dict, external_components: dict):
+def generate_json_architecture(information_flows: dict):
     """Creates JSON file that contains a list of plain information flows, without annotations.
     """
 
@@ -32,6 +32,6 @@ def write_to_file(architecture_dict):
     repo_path = tmp.tmp_config["Repository"]["path"]
     repo_path = repo_path.replace("/", "--")
     filename = "./output/architecture/" + repo_path + ".json"
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, 'w') as architecture_file:
-        json.dump(architecture_dict, architecture_file, indent = 4)
-    return
+        json.dump(architecture_dict, architecture_file, indent=4)

--- a/output_generators/traceability.py
+++ b/output_generators/traceability.py
@@ -1,5 +1,5 @@
-import ast
 import json
+import os
 
 import tmp.tmp as tmp
 
@@ -168,7 +168,6 @@ def quotate_ids():
     traceability = new_traceability
 
 
-
 def write_to_file():
     """Writes tracebility info from dict to json file.
     """
@@ -176,6 +175,6 @@ def write_to_file():
     repo_path = tmp.tmp_config["Repository"]["path"]
     repo_path = repo_path.replace("/", "_")
     filename = "./output/traceability/" + repo_path + "_traceability.json"
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
     with open(filename, "w") as file:
         file.write(json.dumps(traceability, indent=4))
-    return

--- a/output_generators/visualizer.py
+++ b/output_generators/visualizer.py
@@ -6,14 +6,14 @@ import plantuml
 import output_generators.codeable_models_to_plantuml as codeable_models_to_plantuml
 
 
-def output_png(codeable_models_path: str, repo_path: str):
+def output_png(codeable_models_path: str):
     """Converts CodeableModels output into different PlantUML graphics and renders it as PNG.
     """
 
     new_plantuml, new_plantuml_path = codeable_models_to_plantuml.convert(codeable_models_path)
 
-    generator = plantuml.PlantUML(url = "http://www.plantuml.com/plantuml/img/")
+    generator = plantuml.PlantUML(url="http://www.plantuml.com/plantuml/img/")
     try:
-        png = generator.processes_file(filename = new_plantuml_path, outfile = new_plantuml_path.replace("plantuml_source", "png").replace("txt", "png"))
+        generator.processes_file(filename=new_plantuml_path, outfile=new_plantuml_path.replace("plantuml_source", "png").replace("txt", "png"))
     except Exception:
         print("No connection to the PlantUML server possible or malformed input to the server.")


### PR DESCRIPTION
I ran into code problems running Code2DFD because it gave an error like `Cannot write to output/architecture/xxx.json because output/architecture does not exist`.

So now before all the file writing commands there is `os.makedirs()` to create all the necessary subfolders.

Also, all cases of opening the file are done using `with open(...) as f` since using `file.open()` and `file.close()` is considered unsafe and not recommended.

Additionally, there was the commented-out plaintext writing in `dfd_extraction.py`, which wrote to `output/results`. This might be useful for my research (and generally one more option of output), so I uncommented and reworked it a bit.

Also, some clean-up on the `output_generators` is done - removed extra whitespace and unused parameters/function arguments.