### PR TITLE
Add: use argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,11 @@ The corresponding path only needs to be un-commented for analysis (all others ha
 
 
 ##### 2. Running the tool
-To start the tool via the terminal, simply enter `python3 code2DFD.py` in a command line opened in the root directory.
+To start the tool via the terminal using the config file, simply enter `python3 code2DFD.py --config_path PATH_TO_CONFIG` in a command line opened in the root directory.
+For example, `python3 code2DFD.py --config_path config/config.ini` for the example config in this repository.
 The extraction will start and some status messages appear on the screen.
-Alternatively, the repository path can be given as parameter: `python3 code2DFD.py repository/path`.
-If you want to analyse in application on GitHub, simply put in the GitHub handle.
-For example, for the repository `https://github.com/sqshq/piggymetrics`, run the command `python3 code2DFD.py sqshq/piggymetrics`
-Path as parameter overrules path in config-file.
+If you want to analyse in application on GitHub, simply put in the GitHub handle, using the `--github_path` option.
+For example, for the repository `https://github.com/sqshq/piggymetrics`, run the command `python3 code2DFD.py --github_path sqshq/piggymetrics`
 Once the analysis is finished, the results can be found in the `output/` folder.
 
 To run the tool as a RESTful API service, run `python3 flask_code2DFD.py`.

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -3,10 +3,10 @@
 # Author: Simon Schneider, 2023
 # Contact: simon.schneider@tuhh.de
 
-import sys
 import os
 from configparser import ConfigParser
 from datetime import datetime
+import argparse
 
 import core.dfd_extraction as dfd_extraction
 import core.file_interaction as fi
@@ -61,47 +61,33 @@ def api_invocation(path: str) -> str:
 
 
 def main():
+    parser = argparse.ArgumentParser()
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--config_path", type=str, help="Path to the config file to use")
+    source.add_argument("--github_path", type=str, help="Path to the repository on GitHub as 'repository/path'")
     now = datetime.now()
     start_time = now.strftime("%H:%M:%S")
 
+    args = parser.parse_args()
+
     logger.write_log_message("*** New execution ***", "info")
     logger.write_log_message("Copying config file to tmp file", "debug")
-
-    # Copy config to tmp file
-    ini_config = ConfigParser()
-    ini_config.read('config/config.ini')
-    for section in ["Analysis Settings", "Repository", "Technology Profiles", "DFD"]:     #copying what is needed from config to temp
+    for section in ["Analysis Settings", "Repository", "Technology Profiles", "DFD"]:
         if not tmp.tmp_config.has_section(section):
             tmp.tmp_config.add_section(section)
-        for entry in ini_config[section]:
-            tmp.tmp_config.set(section, entry, ini_config[section][entry])
 
-    arguments = sys.argv
-    invocation_command = "python3"
-    for argument in arguments:
-        invocation_command += " " + argument
-    tmp.tmp_config.set("Repository", "invocation_command", invocation_command)
+    if args.config_path is not None:
+        # Copy config to tmp file
+        ini_config = ConfigParser()
+        ini_config.read(args.config_path)
+        for section in ["Analysis Settings", "Repository", "Technology Profiles", "DFD"]:     #copying what is needed from config to temp
+            for entry in ini_config[section]:
+                tmp.tmp_config.set(section, entry, ini_config[section][entry])
+        clone_repo(tmp.tmp_config.get("Repository", "path"))
 
-    if len(arguments) == 1:
-        repo_path = tmp.tmp_config["Repository"]["path"]
-        print("No repository given as parameter. \
-                \n   You can provide the path as: > python3 code2dfd.py repository/path \
-                \nAnalysing " + repo_path + " as specified in config/config.ini")
-    elif len(arguments) == 2:
-        repo_path = arguments[1]
-        tmp.tmp_config.set("Repository", "path", repo_path)
-    elif len(arguments) >2:
-        print("Please specify the repository paths one by one.")
-        return
-
-    # Create analysed_repositories folder in case it doesn't exist yet (issue #2)
-    os.makedirs(os.path.dirname("./analysed_repositories"), exist_ok=True)
-
-    local_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
-    tmp.tmp_config.set("Repository", "local_path", local_path)
-
-    if not fi.repo_downloaded(local_path):
-        fi.download_repo(repo_path)
+    elif args.github_path is not None:
+        repo_path = args.github_path
+        clone_repo(repo_path)
 
     # calling the actual extraction
     dfd_extraction.perform_analysis()
@@ -111,6 +97,15 @@ def main():
 
     print("\nStarted", start_time)
     print("Finished", end_time)
+
+
+def clone_repo(repo_path):
+    # Create analysed_repositories folder in case it doesn't exist yet (issue #2)
+    os.makedirs(os.path.dirname("./analysed_repositories"), exist_ok=True)
+    local_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    tmp.tmp_config.set("Repository", "local_path", local_path)
+    if not fi.repo_downloaded(local_path):
+        fi.download_repo(repo_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`code2dfd.py` now parses the CLI arguments using `argparse` and has two options: `github_path` for getting the path to GitHub repository and `--config_path` for scanning the config file given in CLI. If passing the GitHub path directly, config file is not parsed. 

For this reason, the part of code that clones the repo is refactored into a separate helper function `clone_repo()`