### PR TITLE
Fix: do not attempt to escape `)` symbol

### DIFF
--- a/output_generators/codeable_model.py
+++ b/output_generators/codeable_model.py
@@ -79,7 +79,7 @@ def output_codeable_model(microservices, information_flows, external_components)
         elif stereotypes:
             new_line = "\n" + name + " = CClass(external_component, \"" + str(external_components[e]["name"]) + "\", stereotype_instances = " + str(stereotypes) + ")"
         else:
-            new_line = "\n" + name + " = CClass(external_component, \"" + str(external_components[e]["name"]) + "\)"
+            new_line = "\n" + name + " = CClass(external_component, \"" + str(external_components[e]["name"]) + ")"
         file_content += new_line
 
 


### PR DESCRIPTION
There was a typo in `codeable_models` generator which tried to escape the `)` symbol on one of the lines, which resulted in a `Warning: invalid escape sequence` being raised