### PR TITLE
fix: microservice, flow and external entities should be lists in JSON

### DIFF
--- a/output_generators/json_architecture.py
+++ b/output_generators/json_architecture.py
@@ -8,9 +8,9 @@ def generate_json_architecture(microservices: dict, information_flows: dict, ext
     """Creates JSON file that contains the complete extracted architecture.
     """
 
-    full_dict = {"microservices": microservices,
-                 "information_flows": information_flows,
-                 "external_components": external_components}
+    full_dict = {"microservices": list(microservices.values()),
+                 "information_flows": list(information_flows.values()),
+                 "external_components": list(external_components.values())}
     
     repo_path = tmp.tmp_config["Repository"]["path"]
     repo_path = repo_path.replace("/", "--")
@@ -19,8 +19,3 @@ def generate_json_architecture(microservices: dict, information_flows: dict, ext
     
     with open(filename, 'w') as architecture_file:
         json.dump(full_dict, architecture_file, indent=4)
-
-    return
-
-
-    


### PR DESCRIPTION
The current implementation of `json_architecture` output generator puts the `microservices`, `information_flows` and `external_components` dictionaries to `JSON` as-is, which results in each component being a value with an index:

```
    "microservices": {
        "0": {
            "servicename": "oauth",
            "type": "service",
            "stereotype_instances": [
                "authorization_server",
                "circuit_breaker",
                "infrastructural"
            ],
            "tagged_values": [
                [
                    "Circuit Breaker",
                    "Hystrix"
                ],
                [
                    "Port",
                    8017
                ],
                [
                    "Authorization Server",
                    "Spring OAuth2"
                ]
            ]
        },
        "1": {
            "servicename": "jmx-monitoring",
            "type": "service",
            "stereotype_instances": [
                "internal"
            ],
            "tagged_values": []
        },
```

It makes sense to convert these into lists so that in a `JSON`, we also have a list of `microservices`, etc, since the indexes do not matter.

Also, this way this `JSON` can be automatically imported as a graph into graph analysis software like `NetworkX`:

```
 "microservices": [
        {
            "servicename": "oauth",
            "type": "service",
            "stereotype_instances": [
                "circuit_breaker",
                "authorization_server",
                "infrastructural"
            ],
            "tagged_values": [
                [
                    "Port",
                    8017
                ],
                [
                    "Authorization Server",
                    "Spring OAuth2"
                ],
                [
                    "Circuit Breaker",
                    "Hystrix"
                ]
            ]
        },
        {
            "servicename": "jmx-monitoring",
            "type": "service",
            "stereotype_instances": [
                "internal"
            ],
            "tagged_values": []
        },
```