### PR TITLE
Refactor input/output; path processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,24 +36,26 @@ For example, `python3 code2DFD.py --config_path config/config.ini` for the examp
 The extraction will start and some status messages appear on the screen.
 If you want to analyse in application on GitHub, simply put in the GitHub handle, using the `--github_path` option.
 For example, for the repository `https://github.com/sqshq/piggymetrics`, run the command `python3 code2DFD.py --github_path sqshq/piggymetrics`
-Once the analysis is finished, the results can be found in the `output/` folder.
 
 To run the tool as a RESTful API service, run `python3 flask_code2DFD.py`.
 This will spawn up a Flask server and you can trigger DFD-extractions by sending a request to or opening your browser at `localhost:5000/dfd?path=*repository/path*`
 
 
 ##### 3. Output
+The tools puts the `PROJECT` analysis output into `code2dfd_output/PROJECT`
 The tool creates multiple outputs:
-- The extracted DFD is saved as a .png rendered with [PlantUML](https://plantuml.com) in `output/png/`.
+- The extracted DFD is saved as a UML diagram in `code2dfd_output/PROJECT/PROJECT_uml.txt`
+and as a .png rendered with [PlantUML](https://plantuml.com) in `code2dfd_output/PROJECT/PROJECT_uml.png`
 An internet connection is needed for this, otherwise no PNG will be created.
-- A machine-readable version of the DFD is created in JSON format in `output/json/`
-- Additionally, a version in [CodeableModels](https://github.com/uzdun/CodeableModels) format is created in `output/codeable_models/`, if you want a more flexible format for further work.
+- A machine-readable version of the DFD is created in JSON format in `code2dfd_output/PROJECT/PROJECT_json_architecture.json`
+  - Edges information only is saved in `code2dfd_output/PROJECT/PROJECT_edges.json`
+- A textual version of the results (list of microservices, external entities, and information flows) is created in `code2dfd_output/PROJECT/PROJECT_results.txt`.
+- Additionally, a version in [CodeableModels](https://github.com/uzdun/CodeableModels) format is created in `code2dfd_output/PROJECT/PROJECT.py`, if you want a more flexible format for further work.
 To render these, you need to install CodeableModels as described on their site.
-Further, our metamodel `microservice_dfds_metamodel.py` is needed for that.
+Further, our metamodel [`microservice_dfds_metamodel.py`](microservice_dfds_metamodel.py) is needed for that.
 If interoperability with other software or further processing of the models is of no concern, this offers no advantages.
 The DFDs rendered by CodeableModels do not follow standard DFD-notation.
-- A textual version of the results (list of microservices, external entities, and information flows) is created in `output/results/`.
-- The traceability information for the DFD items is saved in `output/traceability/`.
+- The traceability information for the DFD items is saved in `code2dfd_output/PROJECT/PROJECT_traceability.json`.
 Note that this is ongoing work and the traceability is not created for all items as of now.
 However, we implemented it for enough items to show that this technique works and the full traceability is only a question of further implementation work.
-- Logs are saved in `output/logs/`.
+- Logs are saved in `code2dfd_output/logs/`.

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -10,7 +10,7 @@ import argparse
 import core.dfd_extraction as dfd_extraction
 import output_generators.logger as logger
 import tmp.tmp as tmp
-from core.file_interaction import get_local_path, clone_repo
+from core.file_interaction import get_output_path, get_local_path, clone_repo
 
 
 def api_invocation(path: str) -> dict:
@@ -98,6 +98,7 @@ def main():
     clone_repo(repo_path, local_path)
     tmp.tmp_config.set("Repository", "path", repo_path) # overwrite with user-provided path
     tmp.tmp_config.set("Repository", "local_path", local_path)
+    tmp.tmp_config.set("Analysis Settings", "output_path", get_output_path(repo_path))
 
     # calling the actual extraction
     dfd_extraction.perform_analysis()

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -3,15 +3,14 @@
 # Author: Simon Schneider, 2023
 # Contact: simon.schneider@tuhh.de
 
-import os
 from configparser import ConfigParser
 from datetime import datetime
 import argparse
 
 import core.dfd_extraction as dfd_extraction
-import core.file_interaction as fi
 import output_generators.logger as logger
 import tmp.tmp as tmp
+from core.file_interaction import get_local_path, clone_repo
 
 
 def api_invocation(path: str) -> dict:
@@ -42,8 +41,7 @@ def api_invocation(path: str) -> dict:
     local_path = get_local_path(repo_path)
     tmp.tmp_config.set("Repository", "local_path", local_path)
 
-    if not fi.repo_downloaded(local_path):
-        fi.download_repo(repo_path, local_path)
+    clone_repo(repo_path, local_path)
 
     # Call extraction
     codeable_models, traceability = dfd_extraction.perform_analysis()
@@ -112,17 +110,6 @@ def main():
 
     print("\nStarted", start_time)
     print("Finished", end_time)
-
-
-def get_local_path(repo_path):
-    return os.path.join(os.getcwd(), "analysed_repositories", *repo_path.split("/")[1:])
-
-
-def clone_repo(repo_path, local_path):
-    # Create analysed_repositories folder in case it doesn't exist yet (issue #2)
-    os.makedirs(os.path.join(os.getcwd(), "analysed_repositories"), exist_ok=True)
-    if not fi.repo_downloaded(local_path):
-        fi.download_repo(repo_path, local_path)
 
 
 if __name__ == '__main__':

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -8,7 +8,7 @@ from datetime import datetime
 import argparse
 
 import core.dfd_extraction as dfd_extraction
-import output_generators.logger as logger
+from output_generators.logger import logger
 import tmp.tmp as tmp
 from core.file_interaction import get_output_path, get_local_path, clone_repo
 
@@ -33,8 +33,8 @@ def api_invocation(path: str) -> dict:
 
     start_time = datetime.now()
 
-    logger.write_log_message("*** New execution ***", "info")
-    logger.write_log_message("Copying config file to tmp file", "debug")
+    logger.info("*** New execution ***")
+    logger.debug("Copying config file to tmp file")
 
     # Overwrite repo_path from config file with the one from the API call
     repo_path = str(path)
@@ -71,8 +71,8 @@ def main():
 
     args = parser.parse_args()
 
-    logger.write_log_message("*** New execution ***", "info")
-    logger.write_log_message("Copying config file to tmp file", "debug")
+    logger.info("*** New execution ***")
+    logger.debug("Copying config file to tmp file")
 
     if args.config_path is not None:
         # Copy config to tmp file

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -14,7 +14,7 @@ import output_generators.logger as logger
 import tmp.tmp as tmp
 
 
-def api_invocation(path: str) -> str:
+def api_invocation(path: str) -> dict:
     """Entry function for when tool is called via API call.
     """
 

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -83,15 +83,9 @@ def main():
             for entry in ini_config[section]:
                 tmp.tmp_config.set(section, entry, ini_config[section][entry])
         repo_path = tmp.tmp_config.get("Repository", "path")
-        local_path = get_local_path(repo_path)
-        tmp.tmp_config.set("Repository", "local_path", local_path)
-        clone_repo(repo_path, local_path)
 
     elif args.github_path is not None:
         repo_path = args.github_path.strip()
-        local_path = get_local_path(repo_path)
-        tmp.tmp_config.set("Repository", "local_path", local_path)
-        clone_repo(repo_path, local_path)
 
         ini_config = ConfigParser()
         ini_config.read('config/config.ini')
@@ -100,7 +94,10 @@ def main():
                 tmp.tmp_config.add_section(section)
             for entry in ini_config[section]:
                 tmp.tmp_config.set(section, entry, ini_config[section][entry])
-        tmp.tmp_config.set("Repository", "path", repo_path) # overwrite with user-provided path
+    local_path = get_local_path(repo_path)
+    clone_repo(repo_path, local_path)
+    tmp.tmp_config.set("Repository", "path", repo_path) # overwrite with user-provided path
+    tmp.tmp_config.set("Repository", "local_path", local_path)
 
     # calling the actual extraction
     dfd_extraction.perform_analysis()

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -1,5 +1,4 @@
 import ast
-import os
 from datetime import datetime
 
 import output_generators.codeable_model as codeable_model
@@ -9,6 +8,7 @@ import output_generators.json_architecture as json_architecture
 import output_generators.json_edges as json_edges
 import output_generators.traceability as traceability
 import output_generators.visualizer as visualizer
+import output_generators.plaintext as plaintext
 from technology_specific_extractors.apache_httpd.aph_entry import detect_apachehttpd_webserver
 from technology_specific_extractors.circuit_breaker.cbr_entry import detect_circuit_breakers
 from technology_specific_extractors.consul.cns_entry import detect_consul
@@ -107,44 +107,13 @@ def perform_analysis():
 
     # Printing
     print("\nFinished extraction")
-    repo_path = repo_path.replace("/", "_")
-    filename = "./output/results/" + repo_path + ".txt"
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    with open(filename, "w") as output_file:
-        if information_flows:
-            output_file.write("\nInformation Flows:\n")
-            for i in information_flows.keys():
-                output_file.write("\n" + str(information_flows[i]))
-
-        if microservices:
-            output_file.write("\nMicroservices:\n")
-            for m in microservices.keys():
-                microservices[m].pop("image", None)
-                microservices[m].pop("pom_path", None)
-                microservices[m].pop("properties", None)
-                output_file.write("\n" + str(microservices[m]))
-
-        if external_components:
-            output_file.write("\nExternal Components:\n")
-            for e in external_components.keys():
-                output_file.write("\n" + str(external_components[e]))
-
-    # Writing dict for calculating metrics
-    filename_dict = "./output/results/" + repo_path + "_dict.txt"
-    os.makedirs(os.path.dirname(filename_dict), exist_ok=True)
-    with open(filename_dict, "w") as output_file_dict:
-        complete = dict()
-        complete["microservices"] = microservices
-        complete["information_flows"] = information_flows
-        complete["external_components"] = external_components
-
-        output_file_dict.write(str(complete))
 
     # Saving
     tmp.tmp_config.set("DFD", "microservices", str(microservices))
     tmp.tmp_config.set("DFD", "information_flows", str(information_flows))
     tmp.tmp_config.set("DFD", "external_components", str(external_components))
 
+    plaintext.write_plaintext(microservices, information_flows, external_components)
     codeable_models, codeable_models_path = codeable_model.output_codeable_model(microservices, information_flows, external_components)
     traceability_content = traceability.output_traceability()
     visualizer.output_png(codeable_models_path)

--- a/core/file_interaction.py
+++ b/core/file_interaction.py
@@ -5,7 +5,7 @@ from configparser import ConfigParser
 
 import requests
 
-import output_generators.logger as logger
+from output_generators.logger import logger
 import core.technology_switch as tech_sw
 import tmp.tmp as tmp
 
@@ -297,9 +297,9 @@ def find_variable(parameter: str, file) -> str:
                             i += 1
                             if parameter_variable in fc["content"][linec + i] and "=" in fc["content"][linec + i]:
                                 variable = fc["content"][linec + i].split("=")[1].strip().strip(";").strip().strip("\"")
-            logger.write_log_message(f"Found {variable} in file {correct_file}", "info")
+            logger.info(f"Found {variable} in file {correct_file}")
         except:
-            logger.write_log_message(f"Could not find a definition for {parameter}", "info")
+            logger.info(f"Could not find a definition for {parameter}")
             return None
     else:           # means that it's a variable in this file -> go through lines to find it
         if parameter[-2:-1] == "()":
@@ -311,9 +311,9 @@ def find_variable(parameter: str, file) -> str:
                     if parameter_variable in file["content"][line] and "=" in file["content"][line] and ("private" in file["content"][line] or "public" in file["content"][line] or "protected" in file["content"][line]):
                         variable = file["content"][line].split("=")[1].strip().strip(";").strip().strip("\"")
                 name = file["name"]
-                logger.write_log_message(f"Found {variable} in this file ({name})", "info")
+                logger.info(f"Found {variable} in this file ({name})")
             except:
-                logger.write_log_message(f"Could not find a definition for {parameter}", "info")
+                logger.info(f"Could not find a definition for {parameter}")
                 return None
     return variable
 

--- a/core/file_interaction.py
+++ b/core/file_interaction.py
@@ -24,7 +24,12 @@ repo_cache = dict()
 exception_counter_repo = 0
 
 
-def get_local_path(repo_path):
+def get_output_path(repo_path: str) -> str:
+    repo_path = repo_path.replace("/", "--")
+    return os.path.join(os.getcwd(), 'code2dfd_output', repo_path)
+
+
+def get_local_path(repo_path: str) -> str:
     return os.path.join(os.getcwd(), "analysed_repositories", *repo_path.split("/")[1:])
 
 

--- a/core/parse_files.py
+++ b/core/parse_files.py
@@ -60,6 +60,7 @@ def parse_properties_file(download_url: str) -> str:
 
     repo_path = tmp.tmp_config["Repository"]["path"]
     file_name = download_url.split(repo_path)[1].strip("/")
+    file_name = '/'.join(file_name.split("/")[1:])
 
     properties = set()
     microservice = [False, False]

--- a/core/technology_switch.py
+++ b/core/technology_switch.py
@@ -1,6 +1,6 @@
 import ast
 
-import output_generators.logger as logger
+from output_generators.logger import logger
 import technology_specific_extractors.database_connections.dbc_entry as dbc
 import technology_specific_extractors.docker_compose.dcm_entry as dcm
 import technology_specific_extractors.feign_client.fgn_entry as fgn
@@ -21,7 +21,7 @@ def get_microservices(dfd) -> dict:
     if tmp.tmp_config.has_option("DFD", "microservices"):
         return ast.literal_eval(tmp.tmp_config["DFD"]["microservices"])
     else:
-        logger.write_log_message("Microservices not set yet, start extraction", "info")
+        logger.info("Microservices not set yet, start extraction")
 
         mvn.set_microservices(dfd)
         grd.set_microservices(dfd)
@@ -37,7 +37,7 @@ def get_information_flows(dfd) -> dict:
     if tmp.tmp_config.has_option("DFD", "information_flows"):
         return ast.literal_eval(tmp.tmp_config["DFD"]["information_flows"])
     else:
-        logger.write_log_message("Information flows not set yet, start extraction", "info")
+        logger.info("Information flows not set yet, start extraction")
         communication_techs_list = ast.literal_eval(tmp.tmp_config["Technology Profiles"]["communication_techs_list"])
         for com_tech in communication_techs_list:
             eval(com_tech[1]).set_information_flows(dfd)

--- a/output_generators/codeable_model.py
+++ b/output_generators/codeable_model.py
@@ -126,14 +126,16 @@ def output_codeable_model(microservices, information_flows, external_components)
 def create_file(model_name: str, content: str):
     """Writes content to file.
     """
-
     model_name = model_name.replace("-", "_")
-    file_path = "./output/codeable_models/" + model_name + ".py"
-    os.makedirs(os.path.dirname(file_path), exist_ok=True)
-    with open(file_path, "w") as file:
+    output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
+    filename = f"{model_name}.py"
+    output_path = os.path.join(output_path, filename)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w") as file:
         file.write(content)
 
-    return file_path
+    return output_path
 
 
 def header():

--- a/output_generators/codeable_models_to_plantuml.py
+++ b/output_generators/codeable_models_to_plantuml.py
@@ -12,8 +12,9 @@ def convert(codeable_models_path: str) -> str:
 
     global plantuml_new
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
-    output_file_path = "./output/png/" + repo_path.replace("/", "--") + ".png"
+    output_file_path = tmp.tmp_config["Analysis Settings"]["output_path"]
+    filename = f"{os.path.split(output_file_path)[1]}_uml.txt"
+    output_file_path = os.path.join(output_file_path, filename)
 
     add_header()
 
@@ -207,5 +208,3 @@ def write_output(output_file_path):
     os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
     with open(output_file_path, 'w+') as output_file:
         output_file.write(plantuml_new)
-
-    return

--- a/output_generators/json_architecture.py
+++ b/output_generators/json_architecture.py
@@ -12,10 +12,10 @@ def generate_json_architecture(microservices: dict, information_flows: dict, ext
                  "information_flows": list(information_flows.values()),
                  "external_components": list(external_components.values())}
     
-    repo_path = tmp.tmp_config["Repository"]["path"]
-    repo_path = repo_path.replace("/", "--")
-    filename = "./output/json_architecture/" + repo_path + ".json"
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    
-    with open(filename, 'w') as architecture_file:
+    output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
+    filename = f"{os.path.split(output_path)[1]}_json_architecture.json"
+    output_path = os.path.join(output_path, filename)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'w') as architecture_file:
         json.dump(full_dict, architecture_file, indent=4)

--- a/output_generators/json_edges.py
+++ b/output_generators/json_edges.py
@@ -27,16 +27,15 @@ def generate_json_edges(information_flows: dict):
     architecture_dict["edges"] = edges_list
     write_to_file(architecture_dict)
 
-    return
-
 
 def write_to_file(architecture_dict):
     """Writes json architecture to file.
     """
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
-    repo_path = repo_path.replace("/", "--")
-    filename = "./output/edges/" + repo_path + ".json"
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    with open(filename, 'w') as architecture_file:
+    output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
+    filename = f"{os.path.split(output_path)[1]}_edges.json"
+    output_path = os.path.join(output_path, filename)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'w') as architecture_file:
         json.dump(architecture_dict, architecture_file, indent=4)

--- a/output_generators/logger.py
+++ b/output_generators/logger.py
@@ -8,13 +8,10 @@ log_level = "DEBUG"
 
 numeric_level = getattr(logging, log_level.upper(), 10)
 LOG_FORMAT = "%(levelname)s %(asctime)s - %(message)s"
-LOG_PATH = "./output/logs/"
+LOG_PATH = os.path.join(os.getcwd(), 'code2dfd_output', 'logs', f"{date.today().strftime("%b-%d-%Y")}--{datetime.now().strftime("%H-%M-%S")}.log")
 os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
-
-#filename = "./output/logs/test.log"
-file = LOG_PATH + date.today().strftime("%b-%d-%Y") + "--" + datetime.now().strftime("%H-%M-%S") + ".log"
 logger = logging.getLogger("tool")
-logging.basicConfig(filename = file, level = numeric_level, format = LOG_FORMAT)
+logging.basicConfig(filename=LOG_PATH, level=numeric_level, format=LOG_FORMAT)
 
 
 # Set log levels of all imported modules to ERROR
@@ -26,10 +23,3 @@ logging.getLogger("json").setLevel(logging.ERROR)
 logging.getLogger("yaml").setLevel(logging.ERROR)
 logging.getLogger("io").setLevel(logging.ERROR)
 logging.getLogger("Github").setLevel(logging.ERROR)
-
-
-def write_log_message(message: str, level: str) -> None:
-    """Writes passed message as passed level to log file"""
-    level = str(level)
-    message = str(message)
-    eval("logger." + level + "(message)")

--- a/output_generators/plaintext.py
+++ b/output_generators/plaintext.py
@@ -1,0 +1,28 @@
+import os
+
+import tmp.tmp as tmp
+
+
+def write_plaintext(microservices, information_flows, external_components):
+    output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
+    filename = f"{os.path.split(output_path)[1]}_results.txt"
+    output_path = os.path.join(output_path, filename)
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w") as output_file:
+        if microservices:
+            output_file.write("Microservices:\n")
+            for m in microservices.keys():
+                microservices[m].pop("image", None)
+                microservices[m].pop("pom_path", None)
+                microservices[m].pop("properties", None)
+                output_file.write("\n" + str(microservices[m]))
+
+        if information_flows:
+            output_file.write("\n\nInformation Flows:\n")
+            for i in information_flows.keys():
+                output_file.write("\n" + str(information_flows[i]))
+
+        if external_components:
+            output_file.write("\n\nExternal Components:\n")
+            for e in external_components.keys():
+                output_file.write("\n" + str(external_components[e]))

--- a/output_generators/traceability.py
+++ b/output_generators/traceability.py
@@ -172,9 +172,10 @@ def write_to_file():
     """Writes tracebility info from dict to json file.
     """
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
-    repo_path = repo_path.replace("/", "_")
-    filename = "./output/traceability/" + repo_path + "_traceability.json"
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    with open(filename, "w") as file:
-        file.write(json.dumps(traceability, indent=4))
+    output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
+    filename = f"{os.path.split(output_path)[1]}_traceability.json"
+    output_path = os.path.join(output_path, filename)
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, 'w') as architecture_file:
+        json.dump(traceability, architecture_file, indent=4)

--- a/output_generators/traceability.py
+++ b/output_generators/traceability.py
@@ -132,8 +132,6 @@ def convert_path_to_url(path: str) -> str:
         return path
 
     repo_path = tmp.tmp_config["Repository"]["path"]
-    if "analysed_repositories" in path:
-        path = ("/").join(path.split("/")[3:])
     url = "https://github.com/" + str(repo_path) + "/blob/master/" + str(path)
 
     return url

--- a/output_generators/visualizer.py
+++ b/output_generators/visualizer.py
@@ -14,6 +14,6 @@ def output_png(codeable_models_path: str):
 
     generator = plantuml.PlantUML(url="http://www.plantuml.com/plantuml/img/")
     try:
-        generator.processes_file(filename=new_plantuml_path, outfile=new_plantuml_path.replace("plantuml_source", "png").replace("txt", "png"))
+        generator.processes_file(filename=new_plantuml_path)
     except Exception:
         print("No connection to the PlantUML server possible or malformed input to the server.")

--- a/technology_specific_extractors/apache_httpd/aph_entry.py
+++ b/technology_specific_extractors/apache_httpd/aph_entry.py
@@ -1,4 +1,5 @@
 import re
+import os
 
 import core.external_components as ext
 import core.file_interaction as fi
@@ -125,8 +126,8 @@ def add_connections_docker(microservices: dict, information_flows: dict, file, d
             config_file_path = line.strip().split(" ")[1]
     if config_file_path:
         if docker_path:
-            complete_config_file_path = ("/").join(docker_path.split("/")[:-1]) + "/" + config_file_path
-            config_file_name = complete_config_file_path.split("/")[-1]
+            complete_config_file_path = os.path.join(os.path.dirname(docker_path), config_file_path)
+            config_file_name = os.path.basename(complete_config_file_path)
             files = fi.get_file_as_lines(config_file_name)
             for f in files:
                 if files[f]["path"] == complete_config_file_path:

--- a/technology_specific_extractors/docker/dcr_entry.py
+++ b/technology_specific_extractors/docker/dcr_entry.py
@@ -9,12 +9,10 @@ def detect_port(path: str) -> int:
     """
 
     port = False
-    repo_path = tmp.tmp_config["Repository"]["path"]
-
-    local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     dirs = list()
-    dirs.append(os.scandir(local_repo_path + "/" + "/".join(path.split("/")[:-1])))
+    dirs.append(os.scandir(os.path.join(local_repo_path, os.path.dirname(path))))
 
     while dirs:
         dir = dirs.pop()

--- a/technology_specific_extractors/docker_compose/dcm_entry.py
+++ b/technology_specific_extractors/docker_compose/dcm_entry.py
@@ -2,7 +2,7 @@ import ast
 import os
 
 import core.file_interaction as fi
-import output_generators.logger as logger
+from output_generators.logger import logger
 import core.technology_switch as tech_sw
 import technology_specific_extractors.docker_compose.dcm_parser as dcm_parser
 import tmp.tmp as tmp
@@ -151,9 +151,9 @@ def get_environment_variables(docker_compose_file_URL: str) -> set:
             try:
                 environment_variables.add((line.split("=")[0].strip(), line.split("=")[1].strip()))
             except:
-                logger.write_log_message("error splitting line in dco_entry.set_microservices", "debug")
+                logger.debug("error splitting line in dco_entry.set_microservices")
     except:
-        logger.write_log_message("No .env file exists", "info")
+        logger.info("No .env file exists")
     return environment_variables
 
 

--- a/technology_specific_extractors/docker_compose/dcm_entry.py
+++ b/technology_specific_extractors/docker_compose/dcm_entry.py
@@ -176,28 +176,26 @@ def detect_microservice(file_path: str, dfd) -> str:
     microservice = False
     dockerfile_path = False
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
-
-    local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     # Find corresponding dockerfile
     dirs = list()
     found_docker = False
 
-    path = ("/").join(file_path.split("/")[:-1])
+    path = os.path.dirname(file_path)
     while not found_docker and path != "":
-        dirs.append(os.scandir(local_repo_path + "/" + path))
+        dirs.append(os.scandir(os.path.join(local_repo_path, path)))
         while dirs:
             dir = dirs.pop()
             for entry in dir:
                 if entry.is_file():
                     if entry.name.casefold() == "dockerfile":
-                        dockerfile_path = entry.path.split(repo_path.split("/")[1])[1].strip("/")
+                        dockerfile_path = os.path.relpath(entry.path, start=local_repo_path).strip("/")
                         found_docker = True
-        path = ("/").join(path.split("/")[:-1])
+        path = os.path.dirname(path)
 
     if dockerfile_path:
-        dockerfile_location = ("/").join(dockerfile_path.split("/")[:-1])
+        dockerfile_location = os.path.dirname(dockerfile_path)
 
     # find docker-compose path
     try:
@@ -209,14 +207,14 @@ def detect_microservice(file_path: str, dfd) -> str:
         if len(raw_files) == 0:
             return microservice
         docker_compose_path = raw_files[0]["path"]          # path in the repo (w/0 "analysed_...")
-        docker_compose_location = ("/").join(docker_compose_path.split("/")[:-1])
+        docker_compose_location = os.path.dirname(docker_compose_path)
     except:
         pass
 
     # path of dockerfile relative to docker-compose file
     # if dockerfile is in same branch in file structure as docker-compose-file:
     try:
-        docker_image = dockerfile_location.replace(docker_compose_location, "").strip("/")
+        docker_image = os.path.relpath(dockerfile_location, start=docker_compose_location).strip("/")
     except:
         pass
 

--- a/technology_specific_extractors/docker_compose/dcm_parser.py
+++ b/technology_specific_extractors/docker_compose/dcm_parser.py
@@ -1,5 +1,6 @@
 import ast
 import re
+from pathlib import Path
 
 import ruamel.yaml
 
@@ -120,8 +121,8 @@ def extract_microservices(file_content, file_name) -> set:
                 new_image = file.get("services", {}).get(s).get("image")
                 image = new_image
                 for id in microservices_dict.keys():
-                    pom_path = microservices_dict[id]["pom_path"]
-                    if new_image.split("/")[-1] == pom_path.split("/")[-2]:
+                    pom_path = Path(microservices_dict[id]["pom_path"])
+                    if new_image.split("/")[-1] == pom_path.parts[-2]:
                         exists = True
                         if "pom_" in microservices_dict[id]["servicename"]:
                             microservices_dict[id]["servicename"] = s
@@ -132,8 +133,8 @@ def extract_microservices(file_content, file_name) -> set:
                 new_build = file.get("services", {}).get(s).get("build")
                 build = new_build
                 for id in microservices_dict.keys():
-                    pom_path = microservices_dict[id]["pom_path"]
-                    if new_build.split("/")[-1] == pom_path.split("/")[-2]:
+                    pom_path = Path(microservices_dict[id]["pom_path"])
+                    if new_build.split("/")[-1] == pom_path.parts[-2]:
                         exists = True
                         if "pom_" in microservices_dict[id]["servicename"]:
                             microservices_dict[id]["servicename"] = s
@@ -393,8 +394,8 @@ def extract_microservices(file_content, file_name) -> set:
                 new_image = file.get(s).get("image")
                 image = new_image
                 for id in microservices_dict.keys():
-                    pom_path = microservices_dict[id]["pom_path"]
-                    if new_image.split("/")[-1] == pom_path.split("/")[-2]:
+                    pom_path = Path(microservices_dict[id]["pom_path"])
+                    if new_image.split("/")[-1] == pom_path.parts[-2]:
                         exists = True
                         if "pom_" in microservices_dict[id]["servicename"]:
                             microservices_dict[id]["servicename"] = s
@@ -405,8 +406,8 @@ def extract_microservices(file_content, file_name) -> set:
                 new_build = file.get(s).get("build")
                 build = new_build
                 for id in microservices_dict.keys():
-                    pom_path = microservices_dict[id]["pom_path"]
-                    if new_build.split("/")[-1] == pom_path.split("/")[-2]:
+                    pom_path = Path(microservices_dict[id]["pom_path"])
+                    if new_build.split("/")[-1] == pom_path.parts[-2]:
                         exists = True
                         if "pom_" in microservices_dict[id]["servicename"]:
                             microservices_dict[id]["servicename"] = s

--- a/technology_specific_extractors/gradle/grd_entry.py
+++ b/technology_specific_extractors/gradle/grd_entry.py
@@ -64,9 +64,7 @@ def used_in_application() -> bool:
     """Checks if application has build.gradle file.
     """
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
-
-    return fi.file_exists("build.gradle", repo_path)
+    return fi.file_exists("build.gradle")
 
 
 def parse_configurations(gradle_file) -> str:

--- a/technology_specific_extractors/gradle/grd_entry.py
+++ b/technology_specific_extractors/gradle/grd_entry.py
@@ -2,7 +2,7 @@ import ast
 import os
 
 import core.file_interaction as fi
-import output_generators.logger as logger
+from output_generators.logger import logger
 import core.parse_files as parse
 import core.technology_switch as tech_sw
 import tmp.tmp as tmp
@@ -100,7 +100,7 @@ def parse_properties_file(gradle_path: str):
             if entry.is_file():
                 if not "test" in entry.path:
                     if entry.path.split("/")[-1] in ["application.properties", "bootstrap.properties"]:
-                        logger.write_log_message("Found application.properties here: " + str(entry.path), "info")
+                        logger.info("Found application.properties here: " + str(entry.path))
                         file_path = entry.path
                         file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
                         new_microservice, new_properties = parse.parse_properties_file(file_url)
@@ -109,7 +109,7 @@ def parse_properties_file(gradle_path: str):
                         if new_properties:
                             properties = properties.union(new_properties)
                     elif entry.path.split("/")[-1] in ["application.yaml", "application.yml", "bootstrap.yml", "bootstrap.yaml", "filebeat.yml", "filebeat.yaml"]:
-                        logger.write_log_message("Found properties file here: " + str(entry.path), "info")
+                        logger.info("Found properties file here: " + str(entry.path))
                         file_path = entry.path
                         file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
 
@@ -151,7 +151,7 @@ def detect_microservice(file_path, dfd):
                 if entry.is_file():
                     if entry.name.casefold() == "build.gradle":
                         gradle_path = ("/").join(entry.path.split("/")[3:])
-                        logger.write_log_message("Found build.gradle here: " + str(entry.path), "info")
+                        logger.info("Found build.gradle here: " + str(entry.path))
                         found_gradle = True
                         gradle_file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + file_path
         path = ("/").join(path.split("/")[:-1])
@@ -170,7 +170,7 @@ def detect_microservice(file_path, dfd):
             gradle_file["content"] = fi.file_as_lines(gradle_file_url)
             microservice, properties = parse_configurations(gradle_file)
     else:
-        logger.write_log_message("Did not find microservice", "info")
+        logger.info("Did not find microservice")
 
     if not microservice[0]:
 

--- a/technology_specific_extractors/gradle/grd_entry.py
+++ b/technology_specific_extractors/gradle/grd_entry.py
@@ -1,5 +1,6 @@
 import ast
 import os
+from pathlib import Path
 
 import core.file_interaction as fi
 from output_generators.logger import logger
@@ -87,32 +88,33 @@ def parse_properties_file(gradle_path: str):
     microservice = [False, False]
     # find properties file
     repo_path = tmp.tmp_config["Repository"]["path"]
-    path = ("/").join(gradle_path.split("/")[:-1])
+    path = os.path.dirname(gradle_path)
 
-    local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     dirs = list()
-    dirs.append(os.scandir(local_repo_path + "/" + path))
+    dirs.append(os.scandir(os.path.join(local_repo_path, path)))
 
     while dirs:
         dir = dirs.pop()
         for entry in dir:
             if entry.is_file():
                 if not "test" in entry.path:
-                    if entry.path.split("/")[-1] in ["application.properties", "bootstrap.properties"]:
+                    if os.path.basename(entry.path) in ["application.properties", "bootstrap.properties"]:
                         logger.info("Found application.properties here: " + str(entry.path))
-                        file_path = entry.path
-                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
+                        file_path = os.path.relpath(entry.path, start=local_repo_path)
+                        file_path_parts = Path(file_path).parts
+                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path_parts)
                         new_microservice, new_properties = parse.parse_properties_file(file_url)
                         if new_microservice[0]:
                             microservice = new_microservice
                         if new_properties:
                             properties = properties.union(new_properties)
-                    elif entry.path.split("/")[-1] in ["application.yaml", "application.yml", "bootstrap.yml", "bootstrap.yaml", "filebeat.yml", "filebeat.yaml"]:
+                    elif os.path.basename(entry.path) in ["application.yaml", "application.yml", "bootstrap.yml", "bootstrap.yaml", "filebeat.yml", "filebeat.yaml"]:
                         logger.info("Found properties file here: " + str(entry.path))
-                        file_path = entry.path
-                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
-
+                        file_path = os.path.relpath(entry.path, start=local_repo_path)
+                        file_path_parts = Path(file_path).parts
+                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path_parts)
                         new_microservice, new_properties = parse.parse_yaml_file(file_url, file_path)
                         if new_microservice[0]:
                             microservice = new_microservice
@@ -139,22 +141,23 @@ def detect_microservice(file_path, dfd):
     path = file_path
     found_gradle = False
 
-    local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     dirs = list()
-    path = ("/").join(path.split("/")[:-1])
+    path = os.path.dirname(path)
     while not found_gradle and path != "":
-        dirs.append(os.scandir(local_repo_path + "/" + path))
+        dirs.append(os.scandir(os.path.join(local_repo_path, path)))
         while dirs:
             dir = dirs.pop()
             for entry in dir:
                 if entry.is_file():
                     if entry.name.casefold() == "build.gradle":
-                        gradle_path = ("/").join(entry.path.split("/")[3:])
                         logger.info("Found build.gradle here: " + str(entry.path))
+                        gradle_path = os.path.relpath(entry.path, start=local_repo_path)
+                        gradle_path_parts = Path(gradle_path).parts
                         found_gradle = True
-                        gradle_file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + file_path
-        path = ("/").join(path.split("/")[:-1])
+                        gradle_file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + "/".join(gradle_path_parts)
+        path = os.path.dirname(path)
 
     if found_gradle:
         gradle_file = dict()
@@ -177,9 +180,7 @@ def detect_microservice(file_path, dfd):
         for m in microservices.keys():
             try:
                 image = microservices[m]["image"]
-                path = "/".join(file_path.split("/")[:-1])
-                path = path.strip(".").strip("/")
-                image = image.strip(".").strip("/")
+                path = os.path.dirname(file_path)
                 if image in path:
                     microservice[0] = microservices[m]["servicename"]
             except:

--- a/technology_specific_extractors/implicit_connections/imp_entry.py
+++ b/technology_specific_extractors/implicit_connections/imp_entry.py
@@ -1,4 +1,5 @@
 import ast
+import os
 
 import requests
 import yaml
@@ -82,7 +83,7 @@ def zuul(microservices):
 
                 repo = fi.get_repo(repo_path)
                 try:
-                    path = ("/").join(microservices[m]["pom_path"].split("/")[:-1])
+                    path = os.path.dirname(microservices[m]["pom_path"])
                 except:
                     break
 
@@ -94,11 +95,12 @@ def zuul(microservices):
                     if c.type == "dir":
                         contents.extend(repo.get_contents(c.path))
                     else:
-                        if c.path.split("/")[-1] == "application.properties":
+                        filename = os.path.basename(c.path)
+                        if filename == "application.properties":
                             logger.info("Found application.properties here: " + str(c.path))
                             file_url = c.download_url
                             new_information_flows = extract_routes_properties(file_url, microservices[m]["servicename"])
-                        elif c.path.split("/")[-1] == "application.yaml" or c.path.split("/")[-1] == "application.yml" or c.path.split("/")[-1] == "bootstrap.yml" or c.path.split("/")[-1] == "bootstrap.yaml":
+                        elif filename == "application.yaml" or filename == "application.yml" or filename == "bootstrap.yml" or filename == "bootstrap.yaml":
                             logger.info("Found properteis file here: " + str(c.path))
                             file_url = c.download_url
                             new_information_flows = extract_routes_yaml(file_url, microservices[m]["servicename"])
@@ -150,13 +152,3 @@ def extract_routes_yaml(url, service):
             return new_information_flows
     except:
         return False
-
-
-
-
-
-
-
-
-
-                    #

--- a/technology_specific_extractors/implicit_connections/imp_entry.py
+++ b/technology_specific_extractors/implicit_connections/imp_entry.py
@@ -4,7 +4,7 @@ import requests
 import yaml
 
 import core.file_interaction as fi
-import output_generators.logger as logger
+from output_generators.logger import logger
 import core.technology_switch as tech_sw
 import tmp.tmp as tmp
 import output_generators.traceability as traceability
@@ -95,11 +95,11 @@ def zuul(microservices):
                         contents.extend(repo.get_contents(c.path))
                     else:
                         if c.path.split("/")[-1] == "application.properties":
-                            logger.write_log_message("Found application.properties here: " + str(c.path), "info")
+                            logger.info("Found application.properties here: " + str(c.path))
                             file_url = c.download_url
                             new_information_flows = extract_routes_properties(file_url, microservices[m]["servicename"])
                         elif c.path.split("/")[-1] == "application.yaml" or c.path.split("/")[-1] == "application.yml" or c.path.split("/")[-1] == "bootstrap.yml" or c.path.split("/")[-1] == "bootstrap.yaml":
-                            logger.write_log_message("Found properteis file here: " + str(c.path), "info")
+                            logger.info("Found properteis file here: " + str(c.path))
                             file_url = c.download_url
                             new_information_flows = extract_routes_yaml(file_url, microservices[m]["servicename"])
 

--- a/technology_specific_extractors/maven/mvn_entry.py
+++ b/technology_specific_extractors/maven/mvn_entry.py
@@ -1,6 +1,7 @@
 import ast
 import os
 import re
+from pathlib import Path
 
 import core.file_interaction as fi
 from output_generators.logger import logger
@@ -147,31 +148,36 @@ def parse_properties_file(pom_path: str):
     microservice = [False, False]
     # find properties file
     repo_path = tmp.tmp_config["Repository"]["path"]
-    path = ("/").join(pom_path.split("/")[:-1])
+    path = os.path.dirname(pom_path)
 
-    local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     dirs = list()
-    dirs.append(os.scandir(local_repo_path + "/" + path))
+    dirs.append(os.scandir(os.path.join(local_repo_path, path)))
 
     while dirs:
         dir = dirs.pop()
         for entry in dir:
             if entry.is_file():
                 if not "test" in entry.path:
-                    if entry.path.split("/")[-1] in ["application.properties", "bootstrap.properties"]:
+                    filename = entry.path.split("/")[-1]
+                    if filename in ["application.properties", "bootstrap.properties"]:
                         logger.info("Found application.properties here: " + str(entry.path))
                         file_path = entry.path
-                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
+                        rel_path = os.path.relpath(file_path, start=local_repo_path)
+                        rel_path_parts = Path(rel_path).parts
+                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + "/".join(rel_path_parts)
                         new_microservice, new_properties = parse.parse_properties_file(file_url)
                         if new_microservice[0]:
                             microservice = new_microservice
                         if new_properties:
                             properties = properties.union(new_properties)
-                    elif entry.path.split("/")[-1] in ["application.yaml", "application.yml", "bootstrap.yml", "bootstrap.yaml", "filebeat.yml", "filebeat.yaml"]:
+                    elif filename in ["application.yaml", "application.yml", "bootstrap.yml", "bootstrap.yaml", "filebeat.yml", "filebeat.yaml"]:
                         logger.info("Found properties file here: " + str(entry.path))
                         file_path = entry.path
-                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
+                        rel_path = os.path.relpath(file_path, start=local_repo_path)
+                        rel_path_parts = Path(rel_path).parts
+                        file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + "/".join(rel_path_parts)
                         new_microservice, new_properties = parse.parse_yaml_file(file_url, file_path)
                         if new_microservice[0]:
                             microservice = new_microservice
@@ -300,22 +306,22 @@ def detect_microservice(file_path, dfd):
     path = file_path
     found_pom = False
 
-    local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     dirs = list()
-    path = ("/").join(path.split("/")[:-1])
+    path = os.path.dirname(path)
     while not found_pom and path != "":
-        dirs.append(os.scandir(local_repo_path + "/" + path))
+        dirs.append(os.scandir(os.path.join(local_repo_path, path)))
         while dirs:
             dir = dirs.pop()
             for entry in dir:
                 if entry.is_file():
                     if entry.name.casefold() == "pom.xml":
-                        pom_path = ("/").join(entry.path.split("/")[3:])
+                        pom_path = os.path.relpath(entry.path, start=local_repo_path)
                         logger.info("Found pom.xml here: " + str(entry.path))
                         found_pom = True
-                        pom_file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
-        path = ("/").join(path.split("/")[:-1])
+                        pom_file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(Path(pom_path).parts)
+        path = os.path.dirname(path)
 
     if found_pom:
         pom_file = dict()
@@ -337,9 +343,7 @@ def detect_microservice(file_path, dfd):
         for m in microservices.keys():
             try:
                 image = microservices[m]["image"]
-                path = "/".join(file_path.split("/")[:-1])
-                path = path.strip(".").strip("/")
-                image = image.strip(".").strip("/")
+                path = os.path.dirname(file_path)
                 if image in path:
                     microservice[0] = microservices[m]["servicename"]
             except:

--- a/technology_specific_extractors/maven/mvn_entry.py
+++ b/technology_specific_extractors/maven/mvn_entry.py
@@ -94,9 +94,7 @@ def used_in_application() -> bool:
     """Checks if application has pom.xml file.
     """
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
-
-    return fi.file_exists("pom.xml", repo_path)
+    return fi.file_exists("pom.xml")
 
 
 def extract_modules(file: list) -> list:

--- a/technology_specific_extractors/maven/mvn_entry.py
+++ b/technology_specific_extractors/maven/mvn_entry.py
@@ -3,7 +3,7 @@ import os
 import re
 
 import core.file_interaction as fi
-import output_generators.logger as logger
+from output_generators.logger import logger
 import core.parse_files as parse
 import core.technology_switch as tech_sw
 import technology_specific_extractors.docker.dcr_entry as dcr
@@ -160,7 +160,7 @@ def parse_properties_file(pom_path: str):
             if entry.is_file():
                 if not "test" in entry.path:
                     if entry.path.split("/")[-1] in ["application.properties", "bootstrap.properties"]:
-                        logger.write_log_message("Found application.properties here: " + str(entry.path), "info")
+                        logger.info("Found application.properties here: " + str(entry.path))
                         file_path = entry.path
                         file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
                         new_microservice, new_properties = parse.parse_properties_file(file_url)
@@ -169,7 +169,7 @@ def parse_properties_file(pom_path: str):
                         if new_properties:
                             properties = properties.union(new_properties)
                     elif entry.path.split("/")[-1] in ["application.yaml", "application.yml", "bootstrap.yml", "bootstrap.yaml", "filebeat.yml", "filebeat.yaml"]:
-                        logger.write_log_message("Found properties file here: " + str(entry.path), "info")
+                        logger.info("Found properties file here: " + str(entry.path))
                         file_path = entry.path
                         file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
                         new_microservice, new_properties = parse.parse_yaml_file(file_url, file_path)
@@ -312,7 +312,7 @@ def detect_microservice(file_path, dfd):
                 if entry.is_file():
                     if entry.name.casefold() == "pom.xml":
                         pom_path = ("/").join(entry.path.split("/")[3:])
-                        logger.write_log_message("Found pom.xml here: " + str(entry.path), "info")
+                        logger.info("Found pom.xml here: " + str(entry.path))
                         found_pom = True
                         pom_file_url = "https://raw.githubusercontent.com/" + repo_path + "/master/" + ("/").join(file_path.split("/")[3:])
         path = ("/").join(path.split("/")[:-1])
@@ -330,7 +330,7 @@ def detect_microservice(file_path, dfd):
             pom_file["content"] = fi.file_as_lines(pom_file_url)
             microservice, properties = parse_configurations(pom_file)
     else:
-        logger.write_log_message("Did not find microservice", "info")
+        logger.info("Did not find microservice")
 
     if not microservice[0]:
 

--- a/technology_specific_extractors/nginx/ngn_entry.py
+++ b/technology_specific_extractors/nginx/ngn_entry.py
@@ -1,4 +1,5 @@
 import ruamel.yaml
+import os
 
 import core.external_components as ext
 import core.file_interaction as fi
@@ -101,8 +102,8 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
                 microservices[id] = dict()
 
                 local_repo_path = tmp.tmp_config["Repository"]["local_path"]
-                docker_path = ("/").join(results[r]["path"].split("/")[:-1]) + "/"
-                docker_path = docker_path.replace(local_repo_path, "")
+                docker_path = os.path.dirname(results[r]["path"])
+                docker_path = os.path.relpath(docker_path, start=local_repo_path)
 
                 service_name = "web-app"
                 # go through dockercompose and see if a build or image fits this. if yes, use that name
@@ -157,7 +158,7 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
                 if "COPY " in line and ".conf" in line:
                     config_name = line.strip().split(" ")[1]
             if config_name:
-                config_path = ("/").join(results[r]["path"].split("/")[:-1]) + "/" + config_name
+                config_path = os.path.join(os.path.dirname(results[r]["path"]), config_name)
                 config_results = fi.get_file_as_lines(config_name)
 
                 for cr in config_results:

--- a/technology_specific_extractors/prometheus/prm_entry.py
+++ b/technology_specific_extractors/prometheus/prm_entry.py
@@ -1,3 +1,5 @@
+import os
+
 import core.file_interaction as fi
 import core.technology_switch as tech_sw
 import tmp.tmp as tmp
@@ -57,13 +59,13 @@ def detect_connections(microservices: dict, information_flows: dict, dockerfile,
     """Parses config file to find connections to prometheus.
     """
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
+    local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
     for line in dockerfile["content"]:
         if "ADD" in line:
             ini_file_path = line.split(" ")[1]
 
-            ini_file_path = "./analysed_repositories/" + repo_path.split("/")[1] + "/" + ("/").join(dockerfile["path"].split("/")[:-1]) + "/" + ini_file_path
+            ini_file_path = os.path.join(local_repo_path, os.path.dirname(dockerfile["path"]), ini_file_path)
 
             with open(ini_file_path, "r") as file:
                 ini_file = list()

--- a/technology_specific_extractors/resttemplate/rst_entry.py
+++ b/technology_specific_extractors/resttemplate/rst_entry.py
@@ -2,7 +2,7 @@ import ast
 
 import core.file_interaction as fi
 import core.technology_switch as tech_sw
-import output_generators.logger as logger
+from output_generators.logger import logger
 import output_generators.traceability as traceability
 import tmp.tmp as tmp
 
@@ -178,7 +178,7 @@ def get_outgoing_endpoints(information_flows: dict, dfd) -> set:
                     if new_outgoing_endpoint:
                         outgoing_endpoints.add((new_outgoing_endpoint, microservice,  files[file]["path"], files[file]["line_nr"], files[file]["span"]))
                     else:
-                        logger.write_log_message("\t\tSomething didn't work", "debug")
+                        logger.debug("\t\tSomething didn't work")
 
     return outgoing_endpoints, information_flows
 
@@ -215,7 +215,7 @@ def find_rst_variable(parameter: str, file: dict, line_nr: int, information_flow
     for p in range(len(parameters)):    # Treat each part individually
         parameters[p] = parameters[p].strip()
         if "(" in parameters[p] or ")" in parameters[p]:
-            logger.write_log_message("\tPart of the string is return value of a function. Can not determine this statically.", "debug")
+            logger.debug("\tPart of the string is return value of a function. Can not determine this statically.")
             return False, information_flows
         elif check_if_variable_is_input(parameters[p], file, line_nr):
             parameters[p] = "{" + parameters[p] + "}"
@@ -260,7 +260,7 @@ def find_rst_variable(parameter: str, file: dict, line_nr: int, information_flow
                             parameters[p], x = find_rst_variable(parameters[p], file, line)      # recursive step
                         if parameters[p] != False:
                             parameters[p] = parameters[p].strip("\"").strip()
-                            logger.write_log_message("\t\tFound " + str(parameters[p]) + " in this file.", "info")
+                            logger.info("\t\tFound " + str(parameters[p]) + " in this file.")
                         found = True
                 # Var injection via @Value
                 elif parameter_variable in file["content"][line]:

--- a/technology_specific_extractors/turbine/trb_entry.py
+++ b/technology_specific_extractors/turbine/trb_entry.py
@@ -151,17 +151,16 @@ def detect_turbine_stream(microservices: dict, information_flows: dict, dfd) -> 
                         traceability.add_trace(trace)
 
                         # find pom_file and check which broker there is a dependency for
-                        repo_path = tmp.tmp_config["Repository"]["path"]
                         path = results[r]["path"]
 
                         found_pom = False
 
-                        local_repo_path = "./analysed_repositories/" + ("/").join(repo_path.split("/")[1:])
+                        local_repo_path = tmp.tmp_config["Repository"]["local_path"]
 
                         dirs = list()
 
-                        path = ("/").join(path.split("/")[:-1])
-                        dirs.append(os.scandir(local_repo_path + "/" + path))
+                        path = os.path.dirname(path)
+                        dirs.append(os.scandir(os.path.join(local_repo_path, path)))
 
                         while path != "" and not found_pom:
                             dir = dirs.pop()
@@ -174,8 +173,8 @@ def detect_turbine_stream(microservices: dict, information_flows: dict, dfd) -> 
                                             if "<artifactId>spring-cloud-starter-stream-rabbit</artifactId>" in line:
                                                 uses_rabbit = True
                                                 trace_info = (results[r]["path"], results[r]["line_nr"], results[r]["span"])
-                            path = ("/").join(path.split("/")[:-1])
-                            dirs.append(os.scandir(local_repo_path + "/" + path))
+                            path = os.path.dirname(path)
+                            dirs.append(os.scandir(os.path.join(local_repo_path, path)))
 
                     if ("Monitoring Dashboard", "Hystrix") in microservices[id]["tagged_values"]:
                         dashboard = microservices[id]["servicename"]


### PR DESCRIPTION
This PR changes how input/output of the tool is handled, to enable easier processing a batch of projects in a script and get structured output, and makes all path processing use OS-agnostic `os.path` and `pathlib` functions.

- The config datastrcture how has `["Repository"]["local_path"]` calculcated in `code2DFD.py` on startup. All functions that need to access the actual repository files now access this parameter instead of computing the path themselves, thus removing code duplication;
    - This required changing all path processing in the code to use `os.path` or `pathlib` functions, since all path slicing operation relied on the fact the path begins with `./analysed_repositories`
- `clone_repo()`is refactored from `code2DFD.py` to `file_interaction.py`
- Some boolean-returning functions in `file_interaction.py` are simplified, the file is cleaned-up (whitespaces according to Python recommendations, certain built-in names were shadowed by local variables, which have been renamed;
- The config datastructure now has `["Analysis Settings"]["output_path"]` set in `code2DFD.py`during stratup. All output generators read the path and add their own files accordingly. The output path is changed from `output/PROJECT_FILES` to `code2dfd_output/PROJECT/PROJECT_FILES`, so that the output is more structured if executed on a batch of projects.
- Plaintext output generation which was in `dfd_extraction` is refactored into another `output_generator`; the dict plaintext generation is removed since it is now almost equivalent to `json_architecture`;
- Default config file is not read; instead, all the default values are now constants in the `code2DFD.py`; config file is only read when explicitly provided by user with `--config_path`;
- Logger now logs to `code2DFD_output/logs`. The `write_log_message()` function is removed, instead the logger itself is imported into the components that need it and logging built-in functions like `info()`, `debug()` are used;

I suggest reviewing the PR commit by commit, otherwise the diffs are too big to understand