### PR TITLE
Improvements to merging duplicates 

### DIFF
--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -223,7 +223,7 @@ def overwrite_port(microservices: dict) -> dict:
                 if port:
                     # Traceability
                     trace = dict()
-                    trace["parent_item"] = microservices[m]["servicename"]
+                    trace["parent_item"] = microservices[m]["name"]
                     trace["item"] = "Port"
                     trace["file"] = prop[2][0]
                     trace["line"] = prop[2][1]
@@ -307,14 +307,14 @@ def detect_miscellaneous(microservices: dict, information_flows: dict, external_
                     except:
                         id2 = 0
                     information_flows[id2] = dict()
-                    information_flows[id2]["sender"] = microservices[m]["servicename"]
+                    information_flows[id2]["sender"] = microservices[m]["name"]
                     information_flows[id2]["receiver"] = "mail-server"
                     information_flows[id2]["stereotype_instances"] = ["restful_http"]
                     if mail_password:
                         information_flows[id2]["stereotype_instances"].append("plaintext_credentials_link")
 
                     trace = dict()
-                    trace["item"] = microservices[m]["servicename"] + " -> mail-server"
+                    trace["item"] = microservices[m]["name"] + " -> mail-server"
                     trace["file"] = prop[2][0]
                     trace["line"] = prop[2][1]
                     trace["span"] = prop[2][2]
@@ -372,11 +372,11 @@ def detect_miscellaneous(microservices: dict, information_flows: dict, external_
                         id2 = 0
                     information_flows[id2] = dict()
                     information_flows[id2]["sender"] = "external-website"
-                    information_flows[id2]["receiver"] = microservices[m]["servicename"]
+                    information_flows[id2]["receiver"] = microservices[m]["name"]
                     information_flows[id2]["stereotype_instances"] = ["restful_http"]
 
                     trace = dict()
-                    trace["item"] = "external-website -> " + microservices[m]["servicename"]
+                    trace["item"] = "external-website -> " + microservices[m]["name"]
                     trace["file"] = prop[2][0]
                     trace["line"] = prop[2][1]
                     trace["span"] = prop[2][2]
@@ -393,12 +393,12 @@ def detect_miscellaneous(microservices: dict, information_flows: dict, external_
                                 except:
                                     id = 0
                                 information_flows[id] = dict()
-                                information_flows[id]["sender"] = microservices[m2]["servicename"]
-                                information_flows[id]["receiver"] = microservices[m]["servicename"]
+                                information_flows[id]["sender"] = microservices[m2]["name"]
+                                information_flows[id]["receiver"] = microservices[m]["name"]
                                 information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                                 trace = dict()
-                                trace["item"] = microservices[m2]["servicename"] + " -> " + microservices[m]["servicename"]
+                                trace["item"] = microservices[m2]["name"] + " -> " + microservices[m]["name"]
                                 trace["file"] = prop[2][0]
                                 trace["line"] = prop[2][1]
                                 trace["span"] = prop[2][2]
@@ -446,10 +446,10 @@ def merge_duplicate_services(microservices: dict, external_components: dict) -> 
     for i in microservices.keys():
         for j in microservices.keys():
             if not i == j and not i in keep and not j in keep:
-                if microservices[i]["servicename"] == microservices[j]["servicename"]:
+                if microservices[i]["name"] == microservices[j]["name"]:
                     # merge
                     for property in microservices[j].keys():
-                        if not property == "servicename":
+                        if not property == "name":
                             try:        # service i has same propert -> merge them
                                 microservices[i][property] = microservices[i][property] + microservices[j][property]
                             except:     # service i does not have this property -> set it

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -219,11 +219,11 @@ def overwrite_port(microservices: dict) -> dict:
     """Writes port from properties to tagged vallues.
     """
 
-    for m in microservices.keys():
-        port = False
-        for prop in microservices[m]["properties"]:
+    for microservice in microservices.values():
+        for prop in microservice.get("properties", []):
             if prop[0] == "port":
-                if type(prop[1]) == str:
+                port = None
+                if isinstance(prop[1], str):
                     if "port" in prop[1].casefold():
                         port = prop[1].split(":")[1].strip("}")
                     else:
@@ -233,17 +233,14 @@ def overwrite_port(microservices: dict) -> dict:
                 if port:
                     # Traceability
                     trace = dict()
-                    trace["parent_item"] = microservices[m]["name"]
+                    trace["parent_item"] = microservice["name"]
                     trace["item"] = "Port"
                     trace["file"] = prop[2][0]
                     trace["line"] = prop[2][1]
                     trace["span"] = prop[2][2]
 
                     traceability.add_trace(trace)
-                    if "tagged_values" in microservices[m]:
-                        microservices[m]["tagged_values"].append(("Port", port))
-                    else:
-                        microservices[m]["tagged_values"] = [("Port", port)]
+                    microservice["tagged_values"] = microservice.get("tagged_values", list()) + [("Port", port)]
 
     return microservices
 

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -483,10 +483,13 @@ def merge_duplicate_annotations(collection: dict) -> dict:
             tagged_values_set = set()
             for tag, tagged_value in item["tagged_values"]:
                 if tag == "Port":
-                    try:
-                        tagged_value = int(tagged_value)
-                    except ValueError:
-                        pass
+                    if isinstance(tagged_value, str):
+                        tagged_value = tagged_value.split("/")[0]  # Could be a protocol like 3306/tcp
+                    if not isinstance(tagged_value, int):
+                        try:
+                            tagged_value = int(tagged_value)
+                        except ValueError:
+                            pass
                 elif isinstance(tagged_value, list):
                     tagged_value = str(tagged_value)
                 tagged_values_set.add((tag, tagged_value))

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -179,7 +179,7 @@ def classify_brokers(microservices: dict) -> dict:
     return microservices
 
 
-def classify_microservices(microservices: dict, information_flows: dict, external_components: dict, dfd) -> dict:
+def classify_microservices(microservices: dict, information_flows: dict, external_components: dict, dfd) -> tuple[dict, dict, dict]:
     """Tries to determine the microservice's funcitonality.
     """
 
@@ -245,7 +245,7 @@ def overwrite_port(microservices: dict) -> dict:
     return microservices
 
 
-def detect_miscellaneous(microservices: dict, information_flows: dict, external_components: dict) -> dict:
+def detect_miscellaneous(microservices: dict, information_flows: dict, external_components: dict) -> tuple[dict, dict, dict]:
     """Goes through properties extracted for each service to check for some things that don't fit anywhere else (mail servers, external websites, etc.).
     """
 

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -455,7 +455,7 @@ def merge_duplicate_nodes(nodes: dict) -> dict:
                 if node_i["name"] == node_j["name"]:
                     # merge
                     for property in node_j.keys():
-                        if not property == "name":
+                        if property not in ["name", "type"]:
                             try:        # service i has same propert -> merge them
                                 node_i[property] = node_i[property] + node_j[property]
                             except:     # service i does not have this property -> set it

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -425,12 +425,9 @@ def merge_duplicate_flows(information_flows: dict) -> dict:
                 if flow_i["sender"] == flow_j["sender"]:
                     if flow_i["receiver"] == flow_j["receiver"]:
                         # merge
-                        for property in flow_j.keys():
-                            if not property == "sender" and not property == "receiver":
-                                try:        # flow i has same propert -> merge them
-                                    flow_i[property] = flow_i[property] + flow_j[property]
-                                except:     # flow i does not have this property -> set it
-                                    flow_i[property] = flow_j[property]
+                        for field, j_value in flow_j.items():
+                            if field not in ["sender", "receiver"]:
+                                flow_i[field] = flow_i.get(field, list()) + list(j_value)
                         to_delete.add(j)
                         keep.add(i)
 
@@ -443,7 +440,7 @@ def merge_duplicate_flows(information_flows: dict) -> dict:
 
 
 def merge_duplicate_nodes(nodes: dict) -> dict:
-    """Merge duplicate microservices
+    """Merge duplicate nodes
     """
 
     # Microservices
@@ -454,19 +451,16 @@ def merge_duplicate_nodes(nodes: dict) -> dict:
             if not i == j and i not in keep and j not in keep:
                 if node_i["name"] == node_j["name"]:
                     # merge
-                    for property in node_j.keys():
-                        if property not in ["name", "type"]:
-                            try:        # service i has same propert -> merge them
-                                node_i[property] = node_i[property] + node_j[property]
-                            except:     # service i does not have this property -> set it
-                                node_i[property] = node_j[property]
+                    for field, j_value in node_j.items():
+                        if field not in ["name", "type"]:
+                            node_i[field] = node_i.get(field, list()) + list(j_value)
                     to_delete.add(j)
                     keep.add(i)
 
     nodes_new = dict()
-    for old in nodes.keys():
+    for old, item in nodes.items():
         if old not in to_delete:
-            nodes_new[old] = nodes[old]
+            nodes_new[old] = item
 
     return nodes_new
 
@@ -477,26 +471,19 @@ def merge_duplicate_annotations(collection: dict) -> dict:
 
     for item in collection.values():
         if "stereotype_instances" in item:
-            stereotype_set = set()
-            for stereotype in item["stereotype_instances"]:
-                stereotype_set.add(stereotype)
-            item["stereotype_instances"] = list(stereotype_set)
+            item["stereotype_instances"] = list(set(item["stereotype_instances"]))
 
         if "tagged_values" in item:
             tagged_values_set = set()
-            for tagged_value in item["tagged_values"]:
-                if tagged_value[0] == "Port":
+            for tag, tagged_value in item["tagged_values"]:
+                if tag == "Port":
                     try:
-                        tagged_values_set.add((tagged_value[0], int(tagged_value[1])))
-                    except:
+                        tagged_value = int(tagged_value)
+                    except ValueError:
                         pass
-                elif type(tagged_value[1]) == list:
-                    endpoints = list()
-                    for e in tagged_value[1]:
-                        endpoints.append(e)
-                    tagged_values_set.add((tagged_value[0], str(endpoints)))
-                else:
-                    tagged_values_set.add((tagged_value[0], tagged_value[1]))
+                elif isinstance(tagged_value, list):
+                    tagged_value = str(tagged_value)
+                tagged_values_set.add((tag, tagged_value))
             item["tagged_values"] = list(tagged_values_set)
 
     return collection

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -103,14 +103,14 @@ def perform_analysis():
     print("Merging duplicate items")
     information_flows = clean_database_connections(microservices, information_flows)
 
-    information_flows = merge_duplicate_flows(information_flows)
+    merge_duplicate_flows(information_flows)
 
-    microservices = merge_duplicate_nodes(microservices)
-    external_components = merge_duplicate_nodes(external_components)
+    merge_duplicate_nodes(microservices)
+    merge_duplicate_nodes(external_components)
 
-    microservices = merge_duplicate_annotations(microservices)
-    information_flows = merge_duplicate_annotations(information_flows)
-    external_components = merge_duplicate_annotations(external_components)
+    merge_duplicate_annotations(microservices)
+    merge_duplicate_annotations(information_flows)
+    merge_duplicate_annotations(external_components)
 
     # Printing
     print("\nFinished extraction")
@@ -414,7 +414,7 @@ def detect_miscellaneous(microservices: dict, information_flows: dict, external_
     return microservices, information_flows, external_components
 
 
-def merge_duplicate_flows(information_flows: dict) -> dict:
+def merge_duplicate_flows(information_flows: dict):
     """Multiple flows with the same sender and receiver might occur. They are merged here.
     """
 
@@ -435,16 +435,11 @@ def merge_duplicate_flows(information_flows: dict) -> dict:
                 if field not in ["sender", "receiver"]:
                     flow_i[field] = flow_i.get(field, list()) + list(j_value)
             to_delete.add(j)
-
-    information_flows_new = dict()
-    for old in information_flows.keys():
-        if old not in to_delete:
-            information_flows_new[old] = information_flows[old]
-
-    return information_flows_new
+    for k in to_delete:
+        del information_flows[k]
 
 
-def merge_duplicate_nodes(nodes: dict) -> dict:
+def merge_duplicate_nodes(nodes: dict):
     """Merge duplicate nodes
     """
 
@@ -464,16 +459,11 @@ def merge_duplicate_nodes(nodes: dict) -> dict:
                 if field not in ["name", "type"]:
                     node_i[field] = node_i.get(field, list()) + list(j_value)
             to_delete.add(j)
-
-    nodes_new = dict()
-    for old, item in nodes.items():
-        if old not in to_delete:
-            nodes_new[old] = item
-
-    return nodes_new
+    for k in to_delete:
+        del nodes[k]
 
 
-def merge_duplicate_annotations(collection: dict) -> dict:
+def merge_duplicate_annotations(collection: dict):
     """Merge annotations of all items
     """
 
@@ -496,5 +486,3 @@ def merge_duplicate_annotations(collection: dict) -> dict:
                     tagged_value = str(tagged_value)
                 tagged_values_set.add((tag, tagged_value))
             item["tagged_values"] = list(tagged_values_set)
-
-    return collection

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -96,6 +96,7 @@ def perform_analysis():
     print("Extracted information flows from API-calls, message brokers, and database connections")
 
     # Detect everything else / execute all technology implementations
+    print("Classifying all services")
     microservices = tech_sw.get_microservices(dfd)
     microservices, information_flows, external_components = classify_microservices(microservices, information_flows, external_components, dfd)
 
@@ -182,7 +183,6 @@ def classify_microservices(microservices: dict, information_flows: dict, externa
     """Tries to determine the microservice's funcitonality.
     """
 
-    print("Classifying all services")
     microservices, information_flows = detect_eureka(microservices, information_flows, dfd)
     microservices, information_flows, external_components = detect_zuul(microservices, information_flows, external_components, dfd)
     microservices, information_flows, external_components = detect_spring_cloud_gateway(microservices, information_flows, external_components, dfd)

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -1,6 +1,7 @@
 import ast
 import os
 from datetime import datetime
+from itertools import combinations
 
 import output_generators.codeable_model as codeable_model
 import core.technology_switch as tech_sw
@@ -418,22 +419,22 @@ def merge_duplicate_flows(information_flows: dict) -> dict:
     """
 
     to_delete = set()
-    keep = set()
-    for i, flow_i in information_flows.items():
+    for i, j in combinations(information_flows.keys(), 2):
+        flow_i = information_flows[i]
         flow_i["sender"] = flow_i["sender"].casefold()
         flow_i["receiver"] = flow_i["receiver"].casefold()
-        for j, flow_j in information_flows.items():
-            flow_j["sender"] = flow_j["sender"].casefold()
-            flow_j["receiver"] = flow_j["receiver"].casefold()
-            if not i == j and i not in keep and j not in keep:
-                if flow_i["sender"] == flow_j["sender"]:
-                    if flow_i["receiver"] == flow_j["receiver"]:
-                        # merge
-                        for field, j_value in flow_j.items():
-                            if field not in ["sender", "receiver"]:
-                                flow_i[field] = flow_i.get(field, list()) + list(j_value)
-                        to_delete.add(j)
-                        keep.add(i)
+        if i == j:
+            continue
+        flow_j = information_flows[j]
+        flow_j["sender"] = flow_j["sender"].casefold()
+        flow_j["receiver"] = flow_j["receiver"].casefold()
+
+        if flow_i["sender"] == flow_j["sender"] and flow_i["receiver"] == flow_j["receiver"]:
+            # merge
+            for field, j_value in flow_j.items():
+                if field not in ["sender", "receiver"]:
+                    flow_i[field] = flow_i.get(field, list()) + list(j_value)
+            to_delete.add(j)
 
     information_flows_new = dict()
     for old in information_flows.keys():
@@ -449,19 +450,20 @@ def merge_duplicate_nodes(nodes: dict) -> dict:
 
     # Microservices
     to_delete = set()
-    keep = set()
-    for i, node_i in nodes.items():
+    for i, j in combinations(nodes.keys(), 2):
+        node_i = nodes[i]
         node_i["name"] = node_i["name"].casefold()
-        for j, node_j in nodes.items():
-            node_j["name"] = node_j["name"].casefold()
-            if not i == j and i not in keep and j not in keep:
-                if node_i["name"] == node_j["name"]:
-                    # merge
-                    for field, j_value in node_j.items():
-                        if field not in ["name", "type"]:
-                            node_i[field] = node_i.get(field, list()) + list(j_value)
-                    to_delete.add(j)
-                    keep.add(i)
+        if i == j:
+            continue
+        node_j = nodes[j]
+        node_j["name"] = node_j["name"].casefold()
+
+        if node_i["name"] == node_j["name"]:
+            # merge
+            for field, j_value in node_j.items():
+                if field not in ["name", "type"]:
+                    node_i[field] = node_i.get(field, list()) + list(j_value)
+            to_delete.add(j)
 
     nodes_new = dict()
     for old, item in nodes.items():

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -420,7 +420,11 @@ def merge_duplicate_flows(information_flows: dict) -> dict:
     to_delete = set()
     keep = set()
     for i, flow_i in information_flows.items():
+        flow_i["sender"] = flow_i["sender"].casefold()
+        flow_i["receiver"] = flow_i["receiver"].casefold()
         for j, flow_j in information_flows.items():
+            flow_j["sender"] = flow_j["sender"].casefold()
+            flow_j["receiver"] = flow_j["receiver"].casefold()
             if not i == j and i not in keep and j not in keep:
                 if flow_i["sender"] == flow_j["sender"]:
                     if flow_i["receiver"] == flow_j["receiver"]:
@@ -447,7 +451,9 @@ def merge_duplicate_nodes(nodes: dict) -> dict:
     to_delete = set()
     keep = set()
     for i, node_i in nodes.items():
+        node_i["name"] = node_i["name"].casefold()
         for j, node_j in nodes.items():
+            node_j["name"] = node_j["name"].casefold()
             if not i == j and i not in keep and j not in keep:
                 if node_i["name"] == node_j["name"]:
                     # merge

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -101,7 +101,6 @@ def perform_analysis():
 
     # Merging
     print("Merging duplicate items")
-    information_flows = clean_database_connections(microservices, information_flows)
 
     merge_duplicate_flows(information_flows)
 
@@ -111,6 +110,10 @@ def perform_analysis():
     merge_duplicate_annotations(microservices)
     merge_duplicate_annotations(information_flows)
     merge_duplicate_annotations(external_components)
+
+    print("Cleaning database connections")
+
+    clean_database_connections(microservices, information_flows)
 
     # Printing
     print("\nFinished extraction")

--- a/core/file_interaction.py
+++ b/core/file_interaction.py
@@ -166,7 +166,7 @@ def enrich_output(results: list, microservices: dict):
         o["Import"] = detection_import(o["Line"])
         o["Comment"] = detection_comment(o["Filename"], o["Line"])
         o["Service"] = "None"
-        microservices = [microservices[x]["servicename"] for x in microservices.keys()]
+        microservices = [microservices[x]["name"] for x in microservices.keys()]
         for m in microservices.keys:
             if m in o["Path"]:
                 o["Service"] = m
@@ -250,7 +250,7 @@ def detect_microservice(file_path, dfd):
     """
 
     microservices_set = tech_sw.get_microservices(dfd)
-    microservices = [microservices_set[x]["servicename"] for x in microservices_set.keys()]
+    microservices = [microservices_set[x]["name"] for x in microservices_set.keys()]
 
     file_path_parts = file_path.split("/")
     count = 0
@@ -370,17 +370,17 @@ def resolve_url(url: str, microservice: str, dfd) -> str:
                         for prop in microservices[m]["tagged_values"]:
                             if prop[0] == "Port":
                                 if port == prop[1]:
-                                    target_service = microservices[m]["servicename"]
+                                    target_service = microservices[m]["name"]
         else:
             for m in microservices.keys():
                 url_parts = url.split("/")
                 for url_part in url_parts:
-                    if microservices[m]["servicename"] in url_part.split(":")[0]:
-                        target_service = microservices[m]["servicename"]
+                    if microservices[m]["name"] in url_part.split(":")[0]:
+                        target_service = microservices[m]["name"]
     elif url[0] == "$":  # is environment variable
         if microservice:
             for m in microservices.keys():
-                if microservices[m]["servicename"] == microservice:
+                if microservices[m]["name"] == microservice:
                     try:
                         if "Spring Config" in microservices[m]["properties"]:
                             for mi in microservices.keys():

--- a/output_generators/codeable_model.py
+++ b/output_generators/codeable_model.py
@@ -37,15 +37,15 @@ def output_codeable_model(microservices, information_flows, external_components)
                 stereotypes = str(list(stereotypes))
                 stereotypes = stereotypes.replace("'", "")
 
-        name = str(microservices[m]["servicename"]).replace("-", "_")
+        name = str(microservices[m]["name"]).replace("-", "_")
 
         # Create entry
         if stereotypes and tagged_values:
-            new_line = "\n" + name + " = CClass(service, \"" + str(microservices[m]["servicename"]) + "\", stereotype_instances = " + str(stereotypes) + ", tagged_values = " + str(tagged_values) + ")"
+            new_line = "\n" + name + " = CClass(service, \"" + str(microservices[m]["name"]) + "\", stereotype_instances = " + str(stereotypes) + ", tagged_values = " + str(tagged_values) + ")"
         elif stereotypes:
-            new_line = "\n" + name + " = CClass(service, \"" + str(microservices[m]["servicename"]) + "\", stereotype_instances = " + str(stereotypes) + ")"
+            new_line = "\n" + name + " = CClass(service, \"" + str(microservices[m]["name"]) + "\", stereotype_instances = " + str(stereotypes) + ")"
         else:
-            new_line = "\n" + name + " = CClass(service, \"" + str(microservices[m]["servicename"]) + "\")"
+            new_line = "\n" + name + " = CClass(service, \"" + str(microservices[m]["name"]) + "\")"
 
         file_content += new_line
         last_node = name

--- a/technology_specific_extractors/apache_httpd/aph_entry.py
+++ b/technology_specific_extractors/apache_httpd/aph_entry.py
@@ -96,12 +96,12 @@ def mark_server(microservices: dict, microservice: str) -> dict:
         except:
             id = 0
         microservices[id] = dict()
-        microservices[id]["servicename"] = microservice
+        microservices[id]["name"] = microservice
         microservices[id]["stereotype_instances"] = ["web_server"]
         microservices[id]["tagged_values"] = [("Web Server", "Apache httpd")]
     else:
         for m in microservices.keys():
-            if microservices[m]["servicename"] == microservice: # this is the service
+            if microservices[m]["name"] == microservice: # this is the service
                 try:
                     microservices[m]["stereotype_instances"].append("web_server")
                 except:
@@ -158,12 +158,12 @@ def add_connections(microservices: dict, information_flows: dict, file, microser
                                 for prop in microservices[m]["tagged_values"]:
                                     if prop[0] == "Port":
                                         if str(prop[1]) == str(port):
-                                            target_service = microservices[m]["servicename"]
+                                            target_service = microservices[m]["name"]
                             except Exception as e:
                                 pass
                     else:
                         for m in microservices.keys():
-                            if microservices[m]["servicename"] == host:
+                            if microservices[m]["name"] == host:
                                 target_service = host
                     if target_service:
                         try:

--- a/technology_specific_extractors/circuit_breaker/cbr_entry.py
+++ b/technology_specific_extractors/circuit_breaker/cbr_entry.py
@@ -13,7 +13,7 @@ def detect_circuit_breakers(microservices: dict, information_flows: dict, dfd) -
         circuit_breaker_tuple = False
         correct_id = False
         for m in microservices.keys():
-            if microservices[m]["servicename"] == microservice:
+            if microservices[m]["name"] == microservice:
                 correct_id = m
                 for prop in microservices[m]["properties"]:
                     if prop[0] == "circuit_breaker":

--- a/technology_specific_extractors/consul/cns_entry.py
+++ b/technology_specific_extractors/consul/cns_entry.py
@@ -9,7 +9,7 @@ def detect_consul(microservices: dict, information_flows: dict, dfd) -> dict:
     consul_server = set()
     for m in microservices.keys():
         if "consul:" in microservices[m]["image"]:
-            consul_server.add(microservices[m]["servicename"])
+            consul_server.add(microservices[m]["name"])
             try:
                 microservices[m]["stereotype_instances"].append("service_discovery")
             except:
@@ -32,11 +32,11 @@ def detect_consul(microservices: dict, information_flows: dict, dfd) -> dict:
                                 id = 0
                             information_flows[id] = dict()
                             information_flows[id]["sender"] = consul
-                            information_flows[id]["receiver"] = microservices[m]["servicename"]
+                            information_flows[id]["receiver"] = microservices[m]["name"]
                             information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                             trace = dict()
-                            trace["item"] = consul + " -> " + microservices[m]["servicename"]
+                            trace["item"] = consul + " -> " + microservices[m]["name"]
                             trace["file"] = prop[2][0]
                             trace["line"] = prop[2][1]
                             trace["span"] = prop[2][2]

--- a/technology_specific_extractors/database_connections/dbc_entry.py
+++ b/technology_specific_extractors/database_connections/dbc_entry.py
@@ -44,7 +44,7 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
     for m in microservices.keys():
         database_service, username, password, database_url = False, False, False, False
         trace_info = (False, False, False)
-        sender = microservices[m]["servicename"]
+        sender = microservices[m]["name"]
         for prop in microservices[m]["properties"]:
             if prop[0] == "datasource_url":
                 trace_info = (prop[2][0], prop[2][1], prop[2][2])
@@ -54,19 +54,19 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
                     database_url = prop[1]
                     parts = database_url.split("/")
                     for mi in microservices.keys():
-                        if microservices[mi]["servicename"] in parts:
-                            database_service = microservices[mi]["servicename"]
+                        if microservices[mi]["name"] in parts:
+                            database_service = microservices[mi]["name"]
             elif prop[0] == "datasource_host":
                 trace_info = (prop[2][0], prop[2][1], prop[2][2])
                 for mi in microservices.keys():
-                    if microservices[mi]["servicename"] == prop[1]:
-                        database_service = microservices[mi]["servicename"]
+                    if microservices[mi]["name"] == prop[1]:
+                        database_service = microservices[mi]["name"]
             elif prop[0] == "datasource_uri":
                 trace_info = (prop[2][0], prop[2][1], prop[2][2])
                 database = prop[1].split("://")[1].split("/")[0]
                 for mi in microservices.keys():
-                    if microservices[mi]["servicename"] == database:
-                        database_service = microservices[mi]["servicename"]
+                    if microservices[mi]["name"] == database:
+                        database_service = microservices[mi]["name"]
             if prop[0] == "datasource_username":
                 username = env.resolve_env_var(prop[1])
             if prop[0] == "datasource_password":
@@ -106,7 +106,7 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
             # adjust service to database
             for id in microservices.keys():
 
-                if microservices[id]["servicename"] == database_service:
+                if microservices[id]["name"] == database_service:
                     microservices[id]["type"] = "database_component"
                     if "stereotype_instances" in microservices[id]:
                         microservices[id]["stereotype_instances"].append("database")
@@ -159,12 +159,12 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
             except:
                 id = 0
             external_components[id] = dict()
-            external_components[id]["name"] = "database-" + str(microservices[m]["servicename"])
+            external_components[id]["name"] = "database-" + str(microservices[m]["name"])
             external_components[id]["type"] = "external_component"
             external_components[id]["stereotype_instances"] = ["entrypoint", "exitpoint", "external_database"]
 
             trace = dict()
-            trace["item"] = "database-" + str(microservices[m]["servicename"])
+            trace["item"] = "database-" + str(microservices[m]["name"])
             trace["file"] = trace_info[0]
             trace["line"] = trace_info[1]
             trace["span"] = trace_info[2]
@@ -205,8 +205,8 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
             except:
                 id = 0
             information_flows[id] = dict()
-            information_flows[id]["sender"] = "database-" + str(microservices[m]["servicename"])
-            information_flows[id]["receiver"] = microservices[m]["servicename"]
+            information_flows[id]["sender"] = "database-" + str(microservices[m]["name"])
+            information_flows[id]["receiver"] = microservices[m]["name"]
 
             information_flows[id]["stereotype_instances"] = ["jdbc"]
             if username or password:
@@ -223,7 +223,7 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
             tmp.tmp_config.set("DFD", "external_components", str(external_components))
 
             trace = dict()
-            trace["item"] = "database-" + str(microservices[m]["servicename"]) + " -> " + microservices[m]["servicename"]
+            trace["item"] = "database-" + str(microservices[m]["name"]) + " -> " + microservices[m]["name"]
             trace["file"] = trace_info[0]
             trace["line"] = trace_info[1]
             trace["span"] = trace_info[2]
@@ -241,15 +241,9 @@ def clean_database_connections(microservices: dict, information_flows: dict) -> 
         if microservices[m]["type"] == "database_component":
             to_purge = set()
             for i in information_flows.keys():
-                if information_flows[i]["receiver"] == microservices[m]["servicename"]:
+                if information_flows[i]["receiver"] == microservices[m]["name"]:
                     to_purge.add(i)
             for p in to_purge:
                 information_flows.pop(p)
 
     return information_flows
-
-
-
-
-
-#

--- a/technology_specific_extractors/database_connections/dbc_entry.py
+++ b/technology_specific_extractors/database_connections/dbc_entry.py
@@ -233,17 +233,15 @@ def check_properties(microservices: dict, information_flows: dict, external_comp
     return microservices, information_flows, external_components
 
 
-def clean_database_connections(microservices: dict, information_flows: dict) -> dict:
+def clean_database_connections(microservices: dict, information_flows: dict):
     """Removes database connections in wrong direction, which can occur from docker compose.
     """
 
-    for m in microservices.keys():
-        if microservices[m]["type"] == "database_component":
+    for microservice in microservices.values():
+        if microservice["type"] == "database_component":
             to_purge = set()
             for i in information_flows.keys():
-                if information_flows[i]["receiver"] == microservices[m]["name"]:
+                if information_flows[i]["receiver"] == microservice["name"]:
                     to_purge.add(i)
             for p in to_purge:
-                information_flows.pop(p)
-
-    return information_flows
+                del information_flows[p]

--- a/technology_specific_extractors/databases/dbs_entry.py
+++ b/technology_specific_extractors/databases/dbs_entry.py
@@ -25,7 +25,7 @@ def detect_databases(microservices: dict) -> dict:
                 microservices[m]["tagged_values"] = [("Database", database)]
 
             trace = dict()
-            trace["parent_item"] = microservices[m]["servicename"]
+            trace["parent_item"] = microservices[m]["name"]
             trace["item"] = "database"
             trace["file"] = "heuristic, based on image"
             trace["line"] = "heuristic, based on image"
@@ -63,7 +63,7 @@ def detect_via_docker(microservices: dict, m: int) -> dict:
         except:
             microservices[m]["tagged_values"] = [("Database", database)]
         trace = dict()
-        trace["parent_item"] = microservices[m]["servicename"]
+        trace["parent_item"] = microservices[m]["name"]
         trace["item"] = "database"
         trace["file"] = "heuristic, based on Dockerfile base image"
         trace["line"] = "heuristic, based on Dockerfile base image"

--- a/technology_specific_extractors/docker_compose/dcm_entry.py
+++ b/technology_specific_extractors/docker_compose/dcm_entry.py
@@ -51,7 +51,7 @@ def clean_pom_names(microservices: dict) -> dict:
     """
 
     for m in microservices.keys():
-        microservices[m]["servicename"] = microservices[m]["servicename"].replace("pom_", "")
+        microservices[m]["name"] = microservices[m]["name"].replace("pom_", "")
 
     return microservices
 
@@ -92,7 +92,7 @@ def dictionarify(elements_set: set, properties_dict: dict) -> dict:
             id = 0
         elements[id] = dict()
 
-        elements[id]["servicename"] = e[0]
+        elements[id]["name"] = e[0]
         elements[id]["image"] = e[1]
         elements[id]["type"] = e[2]
         elements[id]["properties"] = properties
@@ -224,7 +224,7 @@ def detect_microservice(file_path: str, dfd) -> str:
     try:
         for m in microservices.keys():
             if microservices[m]["image"] == docker_image:
-                microservice = microservices[m]["servicename"]
+                microservice = microservices[m]["name"]
     except:
         pass
 

--- a/technology_specific_extractors/docker_compose/dcm_parser.py
+++ b/technology_specific_extractors/docker_compose/dcm_parser.py
@@ -91,7 +91,7 @@ def extract_microservices(file_content, file_name) -> set:
             if s == "networks":
                 exists = True
             for id in microservices_dict.keys():
-                if microservices_dict[id]["servicename"] == s:
+                if microservices_dict[id]["name"] == s:
                     exists = True
                     correct_id = id
 
@@ -123,8 +123,8 @@ def extract_microservices(file_content, file_name) -> set:
                     pom_path = microservices_dict[id]["pom_path"]
                     if new_image.split("/")[-1] == pom_path.split("/")[-2]:
                         exists = True
-                        if "pom_" in microservices_dict[id]["servicename"]:
-                            microservices_dict[id]["servicename"] = s
+                        if "pom_" in microservices_dict[id]["name"]:
+                            microservices_dict[id]["name"] = s
             except:
                 pass
 
@@ -135,8 +135,8 @@ def extract_microservices(file_content, file_name) -> set:
                     pom_path = microservices_dict[id]["pom_path"]
                     if new_build.split("/")[-1] == pom_path.split("/")[-2]:
                         exists = True
-                        if "pom_" in microservices_dict[id]["servicename"]:
-                            microservices_dict[id]["servicename"] = s
+                        if "pom_" in microservices_dict[id]["name"]:
+                            microservices_dict[id]["name"] = s
             except:
                 pass
 
@@ -365,7 +365,7 @@ def extract_microservices(file_content, file_name) -> set:
             if s == "networks":
                 exists = True
             for id in microservices_dict.keys():
-                if microservices_dict[id]["servicename"] == s:
+                if microservices_dict[id]["name"] == s:
                     exists = True
                     correct_id = id
 
@@ -396,8 +396,8 @@ def extract_microservices(file_content, file_name) -> set:
                     pom_path = microservices_dict[id]["pom_path"]
                     if new_image.split("/")[-1] == pom_path.split("/")[-2]:
                         exists = True
-                        if "pom_" in microservices_dict[id]["servicename"]:
-                            microservices_dict[id]["servicename"] = s
+                        if "pom_" in microservices_dict[id]["name"]:
+                            microservices_dict[id]["name"] = s
             except:
                 pass
 
@@ -408,8 +408,8 @@ def extract_microservices(file_content, file_name) -> set:
                     pom_path = microservices_dict[id]["pom_path"]
                     if new_build.split("/")[-1] == pom_path.split("/")[-2]:
                         exists = True
-                        if "pom_" in microservices_dict[id]["servicename"]:
-                            microservices_dict[id]["servicename"] = s
+                        if "pom_" in microservices_dict[id]["name"]:
+                            microservices_dict[id]["name"] = s
             except:
                 pass
 
@@ -632,9 +632,9 @@ def extract_information_flows(file_content, microservices, information_flows):
     discovery_server, config_server = False, False
     for m in microservices.keys():
         if "stereotype_instances" in microservices[m] and "service_discovery" in microservices[m]["stereotype_instances"]:
-            discovery_server = microservices[m]["servicename"]
+            discovery_server = microservices[m]["name"]
         if "stereotype_instances" in microservices[m] and "configuration_server" in microservices[m]["stereotype_instances"]:
-            config_server = microservices[m]["servicename"]
+            config_server = microservices[m]["name"]
 
     file = yaml.load(file_content)
 
@@ -646,7 +646,7 @@ def extract_information_flows(file_content, microservices, information_flows):
                 for link in links:
                     found_service = False
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == link:
+                        if microservices[m]["name"] == link:
                             found_service = True
                     if found_service and not link in {discovery_server, config_server}:
                         try:
@@ -667,7 +667,7 @@ def extract_information_flows(file_content, microservices, information_flows):
                 for link in links:
                     found_service = False
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == link:
+                        if microservices[m]["name"] == link:
                             found_service = True
                     if found_service and not link in {discovery_server, config_server}:
                         try:

--- a/technology_specific_extractors/elasticsearch/ela_entry.py
+++ b/technology_specific_extractors/elasticsearch/ela_entry.py
@@ -8,7 +8,7 @@ def detect_elasticsearch(microservices: dict, information_flows: dict, dfd) -> d
     elasticsearch = False
     for m in microservices.keys():
         if "elasticsearch:" in microservices[m]["image"]:
-            elasticsearch = microservices[m]["servicename"]
+            elasticsearch = microservices[m]["name"]
             if "stereotype_instances" in microservices[m]:
                 microservices[m]["stereotype_instances"].append("search_engine")
             else:
@@ -22,7 +22,7 @@ def detect_elasticsearch(microservices: dict, information_flows: dict, dfd) -> d
         kibana = False
         for m in microservices.keys():
             if ("Monitoring Dashboard", "Kibana") in microservices[m]["tagged_values"]:
-                kibana = microservices[m]["servicename"]
+                kibana = microservices[m]["name"]
 
         if kibana:
             try:

--- a/technology_specific_extractors/eureka/eur_entry.py
+++ b/technology_specific_extractors/eureka/eur_entry.py
@@ -15,7 +15,7 @@ def detect_eureka(microservices: dict, information_flows: dict, dfd) -> dict:
         eureka_server = tech_sw.detect_microservice(results[r]["path"], dfd)
 
         for m in microservices.keys():
-            if microservices[m]["servicename"] == eureka_server:        # this is the eureka server
+            if microservices[m]["name"] == eureka_server:        # this is the eureka server
                 try:
                     microservices[m]["stereotype_instances"].append("service_discovery")
                 except:
@@ -51,13 +51,13 @@ def detect_eureka(microservices: dict, information_flows: dict, dfd) -> dict:
         for result_path in result_paths:
             service = tech_sw.detect_microservice(result_path[0], dfd)
             for m in microservices.keys():
-                if microservices[m]["servicename"] == service:
-                    participants.add((microservices[m]["servicename"], result_path[0], result_path[1], result_path[2]))
+                if microservices[m]["name"] == service:
+                    participants.add((microservices[m]["name"], result_path[0], result_path[1], result_path[2]))
 
         for m in microservices.keys():
             for prop in microservices[m]["properties"]:
-                if prop[0] == "eureka_connected" and microservices[m]["servicename"] not in participants:
-                    participants.add((microservices[m]["servicename"], prop[2][0], prop[2][1], prop[2][2]))
+                if prop[0] == "eureka_connected" and microservices[m]["name"] not in participants:
+                    participants.add((microservices[m]["name"], prop[2][0], prop[2][1], prop[2][2]))
 
         for participant in participants:
             if not participant[0] == eureka_server:
@@ -104,7 +104,7 @@ def detect_eureka_server_only(microservices: dict, dfd):
 
     for e in eureka_servers:
         for m in microservices.keys():
-            if microservices[m]["servicename"] == e:        # this is the eureka server
+            if microservices[m]["name"] == e:        # this is the eureka server
                 try:
                     microservices[m]["stereotype_instances"].append("service_discovery")
                 except:

--- a/technology_specific_extractors/feign_client/fgn_entry.py
+++ b/technology_specific_extractors/feign_client/fgn_entry.py
@@ -24,7 +24,7 @@ def set_information_flows(dfd) -> dict:
         for line in results[id]["content"]:
             if "@EnableCircuitBreaker" in line:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["properties"].append("hystrix_enabled")
                         except:
@@ -39,7 +39,7 @@ def set_information_flows(dfd) -> dict:
         load_balancer = "Ribbon"    # default load balancer for FeignClient
         tagged_values = set()
         for m in microservices.keys():
-            if microservices[m]["servicename"] == microservice:
+            if microservices[m]["name"] == microservice:
                 for prop in microservices[m]["properties"]:
                     if prop[0] == "feign_ribbon_disabled":
                         load_balancer = "Spring Cloud Load Balancer" # Load balancer if Ribbon is explicitely disabled (also, recently recommended)
@@ -69,7 +69,7 @@ def set_information_flows(dfd) -> dict:
 
                 if target_service:
                     for m in microservices.keys():
-                        if microservices[m]["servicename"].casefold() == target_service.casefold():
+                        if microservices[m]["name"].casefold() == target_service.casefold():
                             for s in microservices[m]["stereotype_instances"]:
                                 if s == "authentication_scope_all_requests":
                                     stereotype_instances.add("authenticated_request")
@@ -105,7 +105,7 @@ def is_microservice(service: str, dfd) -> bool:
     is_microservice = False
     microservices = tech_sw.get_microservices(dfd)
     for m in microservices.keys():
-        if service.casefold() == microservices[m]["servicename"].casefold():
+        if service.casefold() == microservices[m]["name"].casefold():
             is_microservice = True
 
     return is_microservice

--- a/technology_specific_extractors/gradle/grd_entry.py
+++ b/technology_specific_extractors/gradle/grd_entry.py
@@ -36,7 +36,7 @@ def set_microservices(dfd) -> dict:
                     id = 0
                 microservices[id] = dict()
 
-                microservices[id]["servicename"] = microservice[0]
+                microservices[id]["name"] = microservice[0]
                 microservices[id]["image"] = image
                 microservices[id]["type"] = "internal"
                 microservices[id]["gradle_path"] = gradle_file["path"]
@@ -164,7 +164,7 @@ def detect_microservice(file_path, dfd):
         for m in microservices.keys():
             try:
                 if microservices[m]["gradle_path"] == gradle_path:
-                    microservice[0] = microservices[m]["servicename"]
+                    microservice[0] = microservices[m]["name"]
             except:
                 pass
         if not microservice[0]:
@@ -183,7 +183,7 @@ def detect_microservice(file_path, dfd):
                 path = path.strip(".").strip("/")
                 image = image.strip(".").strip("/")
                 if image in path:
-                    microservice[0] = microservices[m]["servicename"]
+                    microservice[0] = microservices[m]["name"]
             except:
                 pass
 

--- a/technology_specific_extractors/grafana/grf_entry.py
+++ b/technology_specific_extractors/grafana/grf_entry.py
@@ -13,7 +13,7 @@ def detect_grafana(microservices: dict, information_flows: dict, dfd) -> dict:
     for r in results.keys():
         grafana_server = tech_sw.detect_microservice(results[r]["path"], dfd)
         for m in microservices.keys():
-            if microservices[m]["servicename"] == grafana_server:
+            if microservices[m]["name"] == grafana_server:
                 if "stereotype_instances" in microservices[m]:
                     microservices[m]["stereotype_instances"].append("monitoring_dashboard")
                 else:
@@ -24,7 +24,7 @@ def detect_grafana(microservices: dict, information_flows: dict, dfd) -> dict:
                     microservices[m]["tagged_values"] = [("Monitoring Dashboard", "Grafana")]
 
                 trace = dict()
-                trace["parent_item"] = microservices[m]["servicename"]
+                trace["parent_item"] = microservices[m]["name"]
                 trace["item"] = "monitoring_dashboard"
                 trace["file"] = results[r]["path"]
                 trace["line"] = results[r]["line_nr"]

--- a/technology_specific_extractors/html/html_entry.py
+++ b/technology_specific_extractors/html/html_entry.py
@@ -30,7 +30,7 @@ def set_information_flows(dfd):
                     address_parts = address.split("/")
                     for address_part in address_parts:
                         for m in microservices.keys():
-                            if address_part == microservices[m]["servicename"]:
+                            if address_part == microservices[m]["name"]:
                                 microservice = tech_sw.detect_microservice(results[r]["path"], dfd)
                                 if microservice:
                                     try:
@@ -40,11 +40,11 @@ def set_information_flows(dfd):
                                     information_flows[id] = dict()
 
                                     information_flows[id]["sender"] = microservice
-                                    information_flows[id]["receiver"] = microservices[m]["servicename"]
+                                    information_flows[id]["receiver"] = microservices[m]["name"]
                                     information_flows[id]["stereotype_instances"] = stereotypes
 
                                     trace = dict()
-                                    trace["item"] = microservice + " -> " + microservices[m]["servicename"]
+                                    trace["item"] = microservice + " -> " + microservices[m]["name"]
                                     trace["file"] = results[r]["path"]
                                     trace["line"] = results[r]["line_nr"]
                                     trace["span"] = results[r]["span"]

--- a/technology_specific_extractors/http_security/hts_entry.py
+++ b/technology_specific_extractors/http_security/hts_entry.py
@@ -129,7 +129,7 @@ def interpret_configurations(microservices: dict, configuration_tuples: list) ->
                 traceability.add_trace(trace)
 
         for m in microservices.keys():
-            if microservices[m]["servicename"] == configuration_tuple[0]:
+            if microservices[m]["name"] == configuration_tuple[0]:
                 try:
                     microservices[m]["stereotype_instances"] += stereotypes
                 except:

--- a/technology_specific_extractors/hystrix/hsx_entry.py
+++ b/technology_specific_extractors/hystrix/hsx_entry.py
@@ -13,7 +13,7 @@ def detect_hystrix_dashboard(microservices: dict, information_flows: dict, dfd) 
         for line in results[r]["content"]:
             if "@EnableHystrixDashboard" in line:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["stereotype_instances"].append("monitoring_dashboard")
                         except:
@@ -24,7 +24,7 @@ def detect_hystrix_dashboard(microservices: dict, information_flows: dict, dfd) 
                             microservices[m]["tagged_values"] = [("Monitoring Dashboard", "Hystrix")]
 
                         trace = dict()
-                        trace["parent_item"] = microservices[m]["servicename"]
+                        trace["parent_item"] = microservices[m]["name"]
                         trace["item"] = "monitoring_dashboard"
                         trace["file"] = results[r]["path"]
                         trace["line"] = results[r]["line_nr"]
@@ -44,7 +44,7 @@ def detect_hystrix_circuit_breakers(microservices: dict, information_flows: dict
         for line in results[r]["content"]:
             if "@EnableHystrix" in line and not "@EnableHystrixDashboard" in line:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["stereotype_instances"].append("circuit_breaker")
                         except:
@@ -55,7 +55,7 @@ def detect_hystrix_circuit_breakers(microservices: dict, information_flows: dict
                             microservices[m]["tagged_values"] = [("Circuit Breaker", "Hystrix")]
 
                         trace = dict()
-                        trace["parent_item"] = microservices[m]["servicename"]
+                        trace["parent_item"] = microservices[m]["name"]
                         trace["item"] = "circuit_breaker"
                         trace["file"] = results[r]["path"]
                         trace["line"] = results[r]["line_nr"]

--- a/technology_specific_extractors/implicit_connections/imp_entry.py
+++ b/technology_specific_extractors/implicit_connections/imp_entry.py
@@ -51,19 +51,19 @@ def weavescope(microservices):
         for m in microservices.keys():
             if ("Monitoring Dashboard", "Weave Scope") in microservices[m]["tagged_values"]:
                 for mi in microservices.keys():
-                    if not microservices[mi]["servicename"] == microservices[m]["servicename"]:
+                    if not microservices[mi]["name"] == microservices[m]["name"]:
                         try:
                             id = max(new_information_flows.keys()) + 1
                         except:
                             id = 0
                         new_information_flows[id] = dict()
 
-                        new_information_flows[id]["sender"] = microservices[mi]["servicename"]
-                        new_information_flows[id]["receiver"] = microservices[m]["servicename"]
+                        new_information_flows[id]["sender"] = microservices[mi]["name"]
+                        new_information_flows[id]["receiver"] = microservices[m]["name"]
                         new_information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                         trace = dict()
-                        trace["item"] = microservices[mi]["servicename"] + " -> " + microservices[m]["servicename"]
+                        trace["item"] = microservices[mi]["name"] + " -> " + microservices[m]["name"]
                         trace["file"] = "implicit for weavescope"
                         trace["line"] = "implicit for weavescope"
                         trace["span"] = "implicit for weavescope"
@@ -97,11 +97,11 @@ def zuul(microservices):
                         if c.path.split("/")[-1] == "application.properties":
                             logger.write_log_message("Found application.properties here: " + str(c.path), "info")
                             file_url = c.download_url
-                            new_information_flows = extract_routes_properties(file_url, microservices[m]["servicename"])
+                            new_information_flows = extract_routes_properties(file_url, microservices[m]["name"])
                         elif c.path.split("/")[-1] == "application.yaml" or c.path.split("/")[-1] == "application.yml" or c.path.split("/")[-1] == "bootstrap.yml" or c.path.split("/")[-1] == "bootstrap.yaml":
                             logger.write_log_message("Found properteis file here: " + str(c.path), "info")
                             file_url = c.download_url
-                            new_information_flows = extract_routes_yaml(file_url, microservices[m]["servicename"])
+                            new_information_flows = extract_routes_yaml(file_url, microservices[m]["name"])
 
     return new_information_flows
 

--- a/technology_specific_extractors/kafka/kfk_entry.py
+++ b/technology_specific_extractors/kafka/kfk_entry.py
@@ -191,7 +191,7 @@ def match_incoming_to_outgoing_endpoints(microservices: dict, incoming_endpoints
     kafka_server = False
     for id in microservices.keys():
         if ("Message Broker", "Kafka") in microservices[id]["tagged_values"]:
-            kafka_server = microservices[id]["servicename"]
+            kafka_server = microservices[id]["name"]
 
     if kafka_server:
         for i in incoming_endpoints:
@@ -325,8 +325,8 @@ def detect_kafka_server(microservices: dict) -> dict:
                 image = file.get("services", {}).get(s).get("image")
                 if "kafka" in image.split("/")[-1].casefold():
                     for id in microservices.keys():
-                        if microservices[id]["servicename"] == s:
-                            kafka_server = microservices[id]["servicename"]
+                        if microservices[id]["name"] == s:
+                            kafka_server = microservices[id]["name"]
                             try:
                                 microservices[id]["stereotype_instances"].append("message_broker")
                             except:
@@ -337,7 +337,7 @@ def detect_kafka_server(microservices: dict) -> dict:
                                 microservices[id]["tagged_values"] = [("Message Broker", "Kafka")]
 
                             trace = dict()
-                            trace["parent_item"] = microservices[id]["servicename"]
+                            trace["parent_item"] = microservices[id]["name"]
                             trace["item"] = "message_broker"
                             trace["file"] = "heuristic, based on image in Docker Compose"
                             trace["line"] = "heuristic, based on image in Docker Compose"
@@ -352,8 +352,8 @@ def detect_kafka_server(microservices: dict) -> dict:
                 image = file.get(s).get("image")
                 if "kafka" in image.split("/")[-1].casefold():
                     for id in microservices.keys():
-                        if microservices[id]["servicename"] == s:
-                            kafka_server = microservices[id]["servicename"]
+                        if microservices[id]["name"] == s:
+                            kafka_server = microservices[id]["name"]
                             try:
                                 microservices[id]["stereotype_instances"].append("message_broker")
                             except:
@@ -364,7 +364,7 @@ def detect_kafka_server(microservices: dict) -> dict:
                                 microservices[id]["tagged_values"] = [("Message Broker", "Kafka")]
 
                             trace = dict()
-                            trace["parent_item"] = microservices[id]["servicename"]
+                            trace["parent_item"] = microservices[id]["name"]
                             trace["item"] = "message_broker"
                             trace["file"] = "heuristic, based on image in Docker Compose"
                             trace["line"] = "heuristic, based on image in Docker Compose"
@@ -399,14 +399,14 @@ def detect_stream_binders(microservices: dict, information_flows: dict, dfd) -> 
             # Outgoing
             results = fi.search_keywords("@SendTo")
             for r in results.keys():
-                if tech_sw.detect_microservice(results[r]["path"], dfd) == microservices[m]["servicename"]:
+                if tech_sw.detect_microservice(results[r]["path"], dfd) == microservices[m]["name"]:
                     try:
                         id = max(information_flows.keys()) + 1
                     except:
                         id = 0
                     information_flows[id] = dict()
 
-                    information_flows[id]["sender"] = microservices[m]["servicename"]
+                    information_flows[id]["sender"] = microservices[m]["name"]
                     information_flows[id]["receiver"] = kafka_server
                     information_flows[id]["stereotype_instances"] = ["message_producer_kafka", "restful_http"]
                     if out_topic:
@@ -414,7 +414,7 @@ def detect_stream_binders(microservices: dict, information_flows: dict, dfd) -> 
 
                     # Traceability
                     trace = dict()
-                    trace["item"] = str(microservices[m]["servicename"]) + " -> " + str(kafka_server)
+                    trace["item"] = str(microservices[m]["name"]) + " -> " + str(kafka_server)
                     trace["file"] = results[r]["path"]
                     trace["line"] = results[r]["line_nr"]
                     trace["span"] = results[r]["span"]
@@ -422,7 +422,7 @@ def detect_stream_binders(microservices: dict, information_flows: dict, dfd) -> 
                     traceability.add_trace(trace)
 
                     trace = dict()
-                    trace["parent_item"] = str(microservices[m]["servicename"]) + " -> " + str(kafka_server)
+                    trace["parent_item"] = str(microservices[m]["name"]) + " -> " + str(kafka_server)
                     trace["item"] = "message_producer_kafka"
                     trace["file"] = results[r]["path"]
                     trace["line"] = results[r]["line_nr"]
@@ -433,7 +433,7 @@ def detect_stream_binders(microservices: dict, information_flows: dict, dfd) -> 
             # Incoming
             results = fi.search_keywords("@StreamListener")
             for r in results.keys():
-                if tech_sw.detect_microservice(results[r]["path"], dfd) == microservices[m]["servicename"]:
+                if tech_sw.detect_microservice(results[r]["path"], dfd) == microservices[m]["name"]:
 
                     try:
                         id = max(information_flows.keys()) + 1
@@ -442,14 +442,14 @@ def detect_stream_binders(microservices: dict, information_flows: dict, dfd) -> 
                     information_flows[id] = dict()
 
                     information_flows[id]["sender"] = kafka_server
-                    information_flows[id]["receiver"] = microservices[m]["servicename"]
+                    information_flows[id]["receiver"] = microservices[m]["name"]
                     information_flows[id]["stereotype_instances"] = ["message_consumer_kafka", "restful_http"]
                     if in_topic:
                         information_flows[id]["tagged_values"] = {("Consumer Topic", in_topic)}
 
                     # Traceability
                     trace = dict()
-                    trace["item"] = str(kafka_server) + " -> " + str(microservices[m]["servicename"])
+                    trace["item"] = str(kafka_server) + " -> " + str(microservices[m]["name"])
                     trace["file"] = results[r]["path"]
                     trace["line"] = results[r]["line_nr"]
                     trace["span"] = results[r]["span"]
@@ -457,7 +457,7 @@ def detect_stream_binders(microservices: dict, information_flows: dict, dfd) -> 
                     traceability.add_trace(trace)
 
                     trace = dict()
-                    trace["parent_item"] = str(kafka_server) + " -> " + str(microservices[m]["servicename"])
+                    trace["parent_item"] = str(kafka_server) + " -> " + str(microservices[m]["name"])
                     trace["item"] = "message_consumer_kafka"
                     trace["file"] = results[r]["path"]
                     trace["line"] = results[r]["line_nr"]

--- a/technology_specific_extractors/kibana/kib_entry.py
+++ b/technology_specific_extractors/kibana/kib_entry.py
@@ -15,7 +15,7 @@ def detect_kibana(microservices: dict, information_flows: dict, dfd) -> dict:
             except:
                 microservices[m]["tagged_values"] = [("Monitoring Dashboard", "Kibana")]
             trace = dict()
-            trace["parent_item"] = microservices[m]["servicename"]
+            trace["parent_item"] = microservices[m]["name"]
             trace["item"] = "monitoring_dashboard"
             trace["file"] = "heuristic, based on image"
             trace["line"] = "heuristic, based on image"

--- a/technology_specific_extractors/load_balancer/lob_entry.py
+++ b/technology_specific_extractors/load_balancer/lob_entry.py
@@ -13,7 +13,7 @@ def detect_load_balancers(microservices: dict, information_flows: dict, dfd) -> 
 
         correct_id = False
         for m in microservices.keys():
-            if microservices[m]["servicename"] == microservice:
+            if microservices[m]["name"] == microservice:
                 if "stereotype_instances" in microservices[m]:
                     microservices[m]["stereotype_instances"].append("load_balancer")
                 else:

--- a/technology_specific_extractors/local_logging/llo_entry.py
+++ b/technology_specific_extractors/local_logging/llo_entry.py
@@ -31,7 +31,7 @@ def detect_loggerfactory(microservices: dict, dfd) -> dict:
                         for c in ["info", "error", "debug", "trace", "warn"]:
                             if (logger.casefold() + "." + c) in line2.casefold():       # logger is used -> find mciroservice and add stereotype
                                 for m in microservices.keys():
-                                    if microservices[m]["servicename"] == microservice:
+                                    if microservices[m]["name"] == microservice:
                                         try:
                                             microservices[m]["stereotype_instances"] += ["local_logging"]
                                         except:
@@ -39,7 +39,7 @@ def detect_loggerfactory(microservices: dict, dfd) -> dict:
                                         found = True
 
                                         trace = dict()
-                                        trace["parent_item"] = microservices[m]["servicename"]
+                                        trace["parent_item"] = microservices[m]["name"]
                                         trace["item"] = "local_logging"
                                         trace["file"] = results[r]["path"]
                                         trace["line"] = results[r]["line_nr"]
@@ -80,7 +80,7 @@ def detect_lombok(microservices: dict, dfd) -> dict:
             if annotation_found and use_found:
                 microservice = tech_sw.detect_microservice(results[r]["path"], dfd)
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["stereotype_instances"].append("local_logging")
                         except:
@@ -90,7 +90,7 @@ def detect_lombok(microservices: dict, dfd) -> dict:
                         except:
                             microservices[m]["tagged_values"] = [("Logging Technology", "Lombok")]
                         trace = dict()
-                        trace["parent_item"] = microservices[m]["servicename"]
+                        trace["parent_item"] = microservices[m]["name"]
                         trace["item"] = "local_logging"
                         trace["file"] = results[r]["path"]
                         trace["line"] = results[r]["line_nr"]

--- a/technology_specific_extractors/logstash/log_entry.py
+++ b/technology_specific_extractors/logstash/log_entry.py
@@ -10,7 +10,7 @@ def detect_logstash(microservices: dict, information_flows: dict, external_compo
     trace_info = False
     for m in microservices.keys():
         if "logstash:" in microservices[m]["image"]:
-            logstash = microservices[m]["servicename"]
+            logstash = microservices[m]["name"]
             try:
                 microservices[m]["stereotype_instances"].append("logging_server")
             except:
@@ -35,8 +35,8 @@ def detect_logstash(microservices: dict, information_flows: dict, external_compo
                             # internal via name
                             logstash_host = logstash_server.split(":")[0]
                             for mi in microservices.keys():
-                                if logstash_host == microservices[mi]["servicename"]:
-                                    logstash = microservices[mi]["servicename"]
+                                if logstash_host == microservices[mi]["name"]:
+                                    logstash = microservices[mi]["name"]
                                     if "stereotype_instances" in microservices[mi]:
                                         microservices[mi]["stereotype_instances"].append("logging_server")
                                     else:
@@ -52,7 +52,7 @@ def detect_logstash(microservices: dict, information_flows: dict, external_compo
                                 for mi in microservices.keys():
                                     for prop2 in microservices[mi]["properties"]:
                                         if prop2[0] == "Port" and int(prop2[1]) == logstash_port:
-                                            logstash = microservices[mi]["servicename"]
+                                            logstash = microservices[mi]["name"]
                                             if "stereotype_instances" in microservices[mi]:
                                                 microservices[mi]["stereotype_instances"].append("logging_server")
                                             else:
@@ -87,12 +87,12 @@ def detect_logstash(microservices: dict, information_flows: dict, external_compo
                                 except:
                                     id = 0
                                 information_flows[id] = dict()
-                                information_flows[id]["sender"] = microservices[m]["servicename"]
+                                information_flows[id]["sender"] = microservices[m]["name"]
                                 information_flows[id]["receiver"] = "logstash"
                                 information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                                 trace = dict()
-                                trace["item"] = microservices[m]["servicename"] + " -> " + "logstash"
+                                trace["item"] = microservices[m]["name"] + " -> " + "logstash"
                                 trace["file"] = trace_info[0]
                                 trace["line"] = trace_info[1]
                                 trace["span"] = trace_info[2]
@@ -114,7 +114,7 @@ def detect_logstash(microservices: dict, information_flows: dict, external_compo
         elasticsearch = False
         for m in microservices.keys():
             if ("Search Engine", "Elasticsearch") in microservices[m]["tagged_values"]:
-                elasticsearch = microservices[m]["servicename"]
+                elasticsearch = microservices[m]["name"]
         if elasticsearch:
             try:
                 id = max(information_flows.keys()) + 1
@@ -143,12 +143,12 @@ def detect_logstash(microservices: dict, information_flows: dict, external_compo
                         except:
                             id = 0
                         information_flows[id] = dict()
-                        information_flows[id]["sender"] = microservices[m]["servicename"]
+                        information_flows[id]["sender"] = microservices[m]["name"]
                         information_flows[id]["receiver"] = logstash
                         information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                         trace = dict()
-                        trace["item"] = microservices[m]["servicename"] + " -> " + logstash
+                        trace["item"] = microservices[m]["name"] + " -> " + logstash
                         trace["file"] = prop[2][0]
                         trace["line"] = prop[2][1]
                         trace["span"] = prop[2][2]

--- a/technology_specific_extractors/maven/mvn_entry.py
+++ b/technology_specific_extractors/maven/mvn_entry.py
@@ -46,7 +46,7 @@ def set_microservices(dfd) -> dict:
                     id = 0
                 microservices[id] = dict()
 
-                microservices[id]["servicename"] = microservice[0]
+                microservices[id]["name"] = microservice[0]
                 microservices[id]["image"] = image
                 microservices[id]["type"] = "internal"
                 microservices[id]["pom_path"] = pom_file["path"]
@@ -325,7 +325,7 @@ def detect_microservice(file_path, dfd):
         for m in microservices.keys():
             try:
                 if microservices[m]["pom_path"] == pom_path:
-                    microservice[0] = microservices[m]["servicename"]
+                    microservice[0] = microservices[m]["name"]
             except:
                 pass
         if not microservice[0]:
@@ -343,7 +343,7 @@ def detect_microservice(file_path, dfd):
                 path = path.strip(".").strip("/")
                 image = image.strip(".").strip("/")
                 if image in path:
-                    microservice[0] = microservices[m]["servicename"]
+                    microservice[0] = microservices[m]["name"]
             except:
                 pass
 

--- a/technology_specific_extractors/nginx/ngn_entry.py
+++ b/technology_specific_extractors/nginx/ngn_entry.py
@@ -64,7 +64,7 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
 
     for m in microservices.keys():
         if "nginx:" in microservices[m]["image"]:
-            web_app = microservices[m]["servicename"]
+            web_app = microservices[m]["name"]
             correct_id = m
             try:
                 microservices[m]["stereotype_instances"].append("web_application")
@@ -81,7 +81,7 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
             web_service = tech_sw.detect_microservice(results[r]["path"], dfd)
             if web_service:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == web_service:
+                    if microservices[m]["name"] == web_service:
                         web_app = web_service
                         correct_id = m
                         if "stereotype_instances" in microservices[m]:
@@ -134,7 +134,7 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
                             if image == docker_path:
                                 service_name = s
 
-                microservices[id]["servicename"] = service_name
+                microservices[id]["name"] = service_name
                 microservices[id]["image"] = "nginx"
                 microservices[id]["type"] = "service"
                 microservices[id]["docker_path"] = docker_path
@@ -179,18 +179,18 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
                                         if ":" in target:
                                             target_service = target.split(":")[0]
                                             for m in microservices.keys():
-                                                if microservices[m]["servicename"] == target_service:
-                                                    gateway = microservices[m]["servicename"]
+                                                if microservices[m]["name"] == target_service:
+                                                    gateway = microservices[m]["name"]
                                             if not gateway:
                                                 target_port = target.split(":")[1]
                                                 for m in microservices.keys():
                                                     for prop in microservices[m]["tagged_values"]:
                                                         if prop[0] == "Port" and int(prop[1]) == int(target_port):
-                                                            gateway = microservices[m]["servicename"]
+                                                            gateway = microservices[m]["name"]
                                         else:
                                             for m in microservices.keys():
-                                                if microservices[m]["servicename"] == target:
-                                                    gateway = microservices[m]["servicename"]
+                                                if microservices[m]["name"] == target:
+                                                    gateway = microservices[m]["name"]
                                     counter += 1
                             elif "listen " in line2:
                                 try:
@@ -215,12 +215,12 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
         if not gateway:
             for m in microservices.keys():
                 if "stereotype_instances" in microservices[m] and "gateway" in microservices[m]["stereotype_instances"]:
-                    gateway = microservices[m]["servicename"]
+                    gateway = microservices[m]["name"]
 
         if gateway:
             # adjust gateway annotations
             for m in microservices.keys():
-                if microservices[m]["servicename"] == gateway:
+                if microservices[m]["name"] == gateway:
                     if "stereotype_instances" in microservices[m]:
                         if not "gateway" in microservices[m]["stereotype_instances"]:
                             microservices[m]["stereotype_instances"].append("gateway")
@@ -229,7 +229,7 @@ def detect_nginx(microservices: dict, information_flows: dict, external_componen
                             discovery_server = False
                             for mi in microservices.keys():
                                 if "stereotype_instances" in microservices[mi] and "service_discovery" in microservices[mi]["stereotype_instances"]:
-                                    discovery_server = microservices[mi]["servicename"]
+                                    discovery_server = microservices[mi]["name"]
                             if discovery_server:
                                 for i in information_flows:
                                     if information_flows[i]["sender"] == gateway and information_flows[i]["receiver"] == discovery_server:

--- a/technology_specific_extractors/plaintext_credentials/plc_entry.py
+++ b/technology_specific_extractors/plaintext_credentials/plc_entry.py
@@ -51,7 +51,7 @@ def set_plaintext_credentials(microservices: dict) -> dict:
             else:
                 microservices[m]["stereotype_instances"] = ["plaintext_credentials"]
             trace = dict()
-            trace["parent_item"] = microservices[m]["servicename"]
+            trace["parent_item"] = microservices[m]["name"]
             trace["item"] = "plaintext_credentials"
             trace["file"] = trace_info[0]
             trace["line"] = trace_info[1]

--- a/technology_specific_extractors/prometheus/prm_entry.py
+++ b/technology_specific_extractors/prometheus/prm_entry.py
@@ -25,7 +25,7 @@ def detect_server_docker(microservices: dict, information_flows: dict, dfd) -> d
         prometheus_server = tech_sw.detect_microservice(results[r]["path"], dfd) # check if any of the builds correspond to this path. If yes, that's the service
 
         for m in microservices.keys():
-            if microservices[m]["servicename"] == prometheus_server:
+            if microservices[m]["name"] == prometheus_server:
                 if "stereotype_instances" in microservices[m]:
                     microservices[m]["stereotype_instances"].append("metrics_server")
                 else:
@@ -43,7 +43,7 @@ def detect_server_docker(microservices: dict, information_flows: dict, dfd) -> d
             except:
                 id = 0
             microservices[id] = dict()
-            microservices[id]["servicename"] = "prometheus_server"
+            microservices[id]["name"] = "prometheus_server"
             microservices[id]["image"] = results[r]["path"]
             microservices[id]["stereotype_instances"] = ["metrics_server"]
             microservices[id]["tagged_values"] = [("Metrics Server", "Prometheus")]
@@ -84,16 +84,16 @@ def detect_connections(microservices: dict, information_flows: dict, dockerfile,
                                     for prop in microservices[m]["tagged_values"]:
                                         if prop[0] == "Port":
                                             if str(prop[1]) == str(part):
-                                                target_service = microservices[m]["servicename"]
+                                                target_service = microservices[m]["name"]
                                 except:
-                                    print("failed tagged_values for" + microservices[m]["servicename"])
+                                    print("failed tagged_values for" + microservices[m]["name"])
                     else:
                         parts = line.split(":")
                         for part in parts:
                             part = part.strip().strip("[]\'\" ")
                             for m in microservices.keys():
-                                if microservices[m]["servicename"] == part:
-                                    target_service = microservices[m]["servicename"]
+                                if microservices[m]["name"] == part:
+                                    target_service = microservices[m]["name"]
                 if target_service:
                     try:
                         id = max(information_flows.keys()) + 1

--- a/technology_specific_extractors/rabbitmq/rmq_entry.py
+++ b/technology_specific_extractors/rabbitmq/rmq_entry.py
@@ -161,7 +161,7 @@ def match_incoming_to_outgoing_endpoints(incoming_endpoints: set, outgoing_endpo
     rabbit_server = False
     for id in microservices.keys():
         if ("Message Broker", "RabbitMQ") in microservices[id]["tagged_values"]:
-            rabbit_server = microservices[id]["servicename"]
+            rabbit_server = microservices[id]["name"]
             rabbit_id = id
 
     if rabbit_server:
@@ -202,7 +202,7 @@ def match_incoming_to_outgoing_endpoints(incoming_endpoints: set, outgoing_endpo
             username, password, plaintext_credentials = False, False, False
 
             for m in microservices.keys():
-                if microservices[m]["servicename"] == o[2]:
+                if microservices[m]["name"] == o[2]:
                     if "properties" in microservices[m]:
                         for prop in microservices[m]["properties"]:
                             if prop[0] == "rabbit_username":
@@ -323,12 +323,12 @@ def detect_rabbitmq_server(microservices: dict) -> dict:
                 image = file.get("services", {}).get(s).get("image")
                 if "rabbitmq:" in image.split("/")[-1]:
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == s:
+                        if microservices[m]["name"] == s:
                             microservices[m]["stereotype_instances"].append("message_broker")
                             microservices[m]["tagged_values"].append(("Message Broker", "RabbitMQ"))
 
                             trace = dict()
-                            trace["parent_item"] = microservices[m]["servicename"]
+                            trace["parent_item"] = microservices[m]["name"]
                             trace["item"] = "message_broker"
                             trace["file"] = "heuristic, based on image in Docker Compose"
                             trace["line"] = "heuristic, based on image in Docker Compose"
@@ -341,12 +341,12 @@ def detect_rabbitmq_server(microservices: dict) -> dict:
                 build = file.get("services", {}).get(s).get("build")
                 if "rabbitmq" in build or "rabbit-mq" in build:
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == s:
+                        if microservices[m]["name"] == s:
                             microservices[m]["stereotype_instances"].append("message_broker")
                             microservices[m]["tagged_values"].append(("Message Broker", "RabbitMQ"))
 
                             trace = dict()
-                            trace["parent_item"] = microservices[m]["servicename"]
+                            trace["parent_item"] = microservices[m]["name"]
                             trace["item"] = "message_broker"
                             trace["file"] = "heuristic, based on image in Docker Compose"
                             trace["line"] = "heuristic, based on image in Docker Compose"
@@ -360,7 +360,7 @@ def detect_rabbitmq_server(microservices: dict) -> dict:
                 image = file.get(s).get("image")
                 if "rabbitmq:" in image.split("/")[-1]:
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == s:
+                        if microservices[m]["name"] == s:
                             microservices[m]["stereotype_instances"].append("message_broker")
                             microservices[m]["tagged_values"].append(("Message Broker", "RabbitMQ"))
 
@@ -377,7 +377,7 @@ def detect_rabbitmq_server(microservices: dict) -> dict:
                 build = file.get(s).get("build")
                 if "rabbitmq" in build or "rabbit-mq" in build:
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == s:
+                        if microservices[m]["name"] == s:
                             microservices[m]["stereotype_instances"].append("message_broker")
                             microservices[m]["tagged_values"].append(("Message Broker", "RabbitMQ"))
 

--- a/technology_specific_extractors/repository_rest_resource/rrr_entry.py
+++ b/technology_specific_extractors/repository_rest_resource/rrr_entry.py
@@ -17,7 +17,7 @@ def detect_endpoints(microservices: dict, dfd) -> dict:
                     endpoint = "/" + endpoint
                     endpoints.add(endpoint)
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == microservice:
+                        if microservices[m]["name"] == microservice:
                             try:
                                 microservices[m]["tagged_values"].append(("Endpoints", list(endpoints)))
                             except:

--- a/technology_specific_extractors/resttemplate/rst_entry.py
+++ b/technology_specific_extractors/resttemplate/rst_entry.py
@@ -130,7 +130,7 @@ def add_endpoints_tagged_values(endpoint_tuples: list, dfd):
 
     for endpoint in ordered_endpoints.keys():
         for m in microservices.keys():
-            if microservices[m]["servicename"] == endpoint:
+            if microservices[m]["name"] == endpoint:
                 if "tagged_values" in microservices[m].keys():
                     microservices[m]["tagged_values"].append(('Endpoints', list(ordered_endpoints[endpoint])))
                 else:
@@ -145,7 +145,7 @@ def get_outgoing_endpoints(information_flows: dict, dfd) -> set:
     microservices = tech_sw.get_microservices(dfd)
 
     if microservices != None:
-        microservices = [microservices[x]["servicename"] for x in microservices.keys()]
+        microservices = [microservices[x]["name"] for x in microservices.keys()]
     else:
         microservices = list()
     outgoing_endpoints = set()
@@ -188,7 +188,7 @@ def find_rst_variable(parameter: str, file: dict, line_nr: int, information_flow
     # check if service name in parameter, if yes, add flow directly
     microservices = tech_sw.get_microservices(dfd)
     for m in microservices.keys():
-        if microservices[m]["servicename"] in parameter:
+        if microservices[m]["name"] in parameter:
             try:
                 id = max(information_flows.keys()) + 1
             except:
@@ -196,11 +196,11 @@ def find_rst_variable(parameter: str, file: dict, line_nr: int, information_flow
             information_flows[id] = dict()
 
             information_flows[id]["sender"] = microservice
-            information_flows[id]["receiver"] = microservices[m]["servicename"]
+            information_flows[id]["receiver"] = microservices[m]["name"]
             information_flows[id]["stereotype_instances"] = ["restful_http"]
 
             trace = dict()
-            trace["item"] = microservice + " -> " + microservices[m]["servicename"]
+            trace["item"] = microservice + " -> " + microservices[m]["name"]
             trace["file"] = file["path"]
             trace["line"] = file["line_nr"]
             trace["span"] = file["span"]
@@ -332,7 +332,7 @@ def match_incoming_to_outgoing_endpoints(incoming_endpoints: list, outgoing_endp
         stereotype_instances.append("restful_http")
         tagged_values = list()
         for m in microservices.keys():
-            if microservices[m]["servicename"] == i[0]:
+            if microservices[m]["name"] == i[0]:
                 for prop in microservices[m]["properties"]:
                     if prop[0] == "load_balancer":
                         stereotype_instances.append("load_balanced_link")

--- a/technology_specific_extractors/ribbon/rib_entry.py
+++ b/technology_specific_extractors/ribbon/rib_entry.py
@@ -21,7 +21,7 @@ def detect_client_side(microservices: dict, dfd) -> dict:
         for line in results[r]["content"]:
             if "@RibbonClient" in line:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["stereotype_instances"].append("load_balancer")
                         except:

--- a/technology_specific_extractors/service_functionality_classification/itf_entry.py
+++ b/technology_specific_extractors/service_functionality_classification/itf_entry.py
@@ -39,7 +39,7 @@ def classify_internal_infrastructural(microservices: dict) -> dict:
                 microservices[m]["type"] = "service"
                 if deciding_stereotype:
                     trace = dict()
-                    trace["parent_item"] = microservices[m]["servicename"]
+                    trace["parent_item"] = microservices[m]["name"]
                     trace["item"] = "infrastructural"
                     trace["file"] = "heuristic, based on stereotype " + deciding_stereotype
                     trace["line"] = "heuristic, based on stereotype " + deciding_stereotype
@@ -53,7 +53,7 @@ def classify_internal_infrastructural(microservices: dict) -> dict:
                     microservices[m]["stereotype_instances"] = ["internal"]
 
                 trace = dict()
-                trace["parent_item"] = microservices[m]["servicename"]
+                trace["parent_item"] = microservices[m]["name"]
                 trace["item"] = "internal"
                 trace["file"] = "heuristic"
                 trace["line"] = "heuristic"

--- a/technology_specific_extractors/spring_admin/sad_entry.py
+++ b/technology_specific_extractors/spring_admin/sad_entry.py
@@ -12,7 +12,7 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
     for r in results.keys():
         admin_server = tech_sw.detect_microservice(results[r]["path"], dfd)
         for m in microservices.keys():
-            if microservices[m]["servicename"] == admin_server:
+            if microservices[m]["name"] == admin_server:
                 try:
                     microservices[m]["stereotype_instances"].append("administration_server")
                 except:
@@ -21,7 +21,7 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
                     microservices[m]["tagged_values"].append(("Administration Server", "Spring Boot Admin"))
                 except:
                     microservices[m]["tagged_values"] = ("Administration Server", "Spring Boot Admin")
-                admin_server = microservices[m]["servicename"]
+                admin_server = microservices[m]["name"]
 
                 # Traceability
                 trace = dict()
@@ -54,13 +54,13 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
             if reverse: # flow admin -> service-discovery
                 found = False
                 for i in information_flows.keys():
-                    if information_flows[i]["sender"] == admin_server and information_flows[i]["receiver"] == microservices[m]["servicename"]:
+                    if information_flows[i]["sender"] == admin_server and information_flows[i]["receiver"] == microservices[m]["name"]:
                         found = True
-                        information_flows[i]["sender"] = microservices[m]["servicename"]
+                        information_flows[i]["sender"] = microservices[m]["name"]
                         information_flows[i]["receiver"] = admin_server
 
                         trace = dict()
-                        trace["item"] = microservices[m]["servicename"] + " -> " + admin_server
+                        trace["item"] = microservices[m]["name"] + " -> " + admin_server
                         trace["file"] = trace_info[0]
                         trace["line"] = trace_info[1]
                         trace["span"] = trace_info[2]
@@ -74,12 +74,12 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
                         id = 0
                     information_flows[id] = dict()
 
-                    information_flows[id]["sender"] = microservices[m]["servicename"]
+                    information_flows[id]["sender"] = microservices[m]["name"]
                     information_flows[id]["receiver"] = admin_server
                     information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                     trace = dict()
-                    trace["item"] = microservices[m]["servicename"] + " -> " + admin_server
+                    trace["item"] = microservices[m]["name"] + " -> " + admin_server
                     trace["file"] = trace_info[0]
                     trace["line"] = trace_info[1]
                     trace["span"] = trace_info[2]
@@ -90,13 +90,13 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
             elif config_reverse:
                 found = False
                 for i in information_flows.keys():
-                    if information_flows[i]["sender"] == microservices[m]["servicename"] and information_flows[i]["receiver"] == admin_server:
+                    if information_flows[i]["sender"] == microservices[m]["name"] and information_flows[i]["receiver"] == admin_server:
                         found = True
                         information_flows[i]["sender"] = admin_server
-                        information_flows[i]["receiver"] = microservices[m]["servicename"]
+                        information_flows[i]["receiver"] = microservices[m]["name"]
 
                         trace = dict()
-                        trace["item"] = admin_server + " -> " + microservices[m]["servicename"]
+                        trace["item"] = admin_server + " -> " + microservices[m]["name"]
                         trace["file"] = trace_info[0]
                         trace["line"] = trace_info[1]
                         trace["span"] = trace_info[2]
@@ -111,11 +111,11 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
                     information_flows[id] = dict()
 
                     information_flows[id]["sender"] = admin_server
-                    information_flows[id]["receiver"] = microservices[m]["servicename"]
+                    information_flows[id]["receiver"] = microservices[m]["name"]
                     information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                     trace = dict()
-                    trace["item"] = admin_server + " -> " + microservices[m]["servicename"]
+                    trace["item"] = admin_server + " -> " + microservices[m]["name"]
                     trace["file"] = trace_info[0]
                     trace["line"] = trace_info[1]
                     trace["span"] = trace_info[2]
@@ -130,11 +130,11 @@ def detect_spring_admin_server(microservices: dict, information_flows: dict, dfd
 
                 information_flows[id] = dict()
                 information_flows[id]["sender"] = admin_server
-                information_flows[id]["receiver"] = microservices[m]["servicename"]
+                information_flows[id]["receiver"] = microservices[m]["name"]
                 information_flows[id]["stereotype_instances"] = ["restful_http"]
 
                 trace = dict()
-                trace["item"] = admin_server + " -> " + microservices[m]["servicename"]
+                trace["item"] = admin_server + " -> " + microservices[m]["name"]
                 trace["file"] = trace_info[0]
                 trace["line"] = trace_info[1]
                 trace["span"] = trace_info[2]

--- a/technology_specific_extractors/spring_config/cnf_entry.py
+++ b/technology_specific_extractors/spring_config/cnf_entry.py
@@ -37,7 +37,7 @@ def detect_config_server(microservices: dict, dfd):
         config_server = tech_sw.detect_microservice(results[r]["path"], dfd)
 
         for m in microservices.keys():
-            if microservices[m]["servicename"] == config_server:
+            if microservices[m]["name"] == config_server:
                 try:
                     microservices[m]["stereotype_instances"].append("configuration_server")
                 except:
@@ -99,7 +99,7 @@ def detect_config_clients(microservices: dict, information_flows: dict, config_s
     trace_file = False
 
     for m in microservices.keys():
-        if microservices[m]["servicename"] == config_server:
+        if microservices[m]["name"] == config_server:
             config_id = m
         config_uri, config_connected, config_username, config_password = False, False, False, False
         for prop in microservices[m]["properties"]:
@@ -146,12 +146,12 @@ def detect_config_clients(microservices: dict, information_flows: dict, config_s
                 id = 0
             information_flows[id] = dict()
             information_flows[id]["sender"] = config_server
-            information_flows[id]["receiver"] = microservices[m]["servicename"]
+            information_flows[id]["receiver"] = microservices[m]["name"]
             information_flows[id]["stereotype_instances"] = ["restful_http"]
 
             if trace_file:
                 trace = dict()
-                trace["item"] = config_server + " -> " + microservices[m]["servicename"]
+                trace["item"] = config_server + " -> " + microservices[m]["name"]
                 trace["file"] = trace_file
                 trace["line"] = trace_line
                 trace["span"] = trace_span
@@ -172,7 +172,7 @@ def detect_config_clients(microservices: dict, information_flows: dict, config_s
 
                     if trace_file:
                         trace = dict()
-                        trace["parent_item"] = microservices[config_id]["servicename"]
+                        trace["parent_item"] = microservices[config_id]["name"]
                         trace["item"] = "plaintext_credentials"
                         trace["file"] = trace_file
                         trace["line"] = trace_line
@@ -194,7 +194,7 @@ def detect_config_clients(microservices: dict, information_flows: dict, config_s
 
                     if trace_file:
                         trace = dict()
-                        trace["parent_item"] = microservices[config_id]["servicename"]
+                        trace["parent_item"] = microservices[config_id]["name"]
                         trace["item"] = "plaintext_credentials"
                         trace["file"] = trace_file
                         trace["line"] = trace_line
@@ -256,16 +256,16 @@ def parse_config_files(config_server: str, config_path: str, config_file_path: s
             microservice = False
             properties = set()
             for m in microservices.keys():
-                if file[0].split(".")[0] == microservices[m]["servicename"]:
-                    microservice = microservices[m]["servicename"]
+                if file[0].split(".")[0] == microservices[m]["name"]:
+                    microservice = microservices[m]["name"]
                     correct_id = m
                     if "." in file[0]:
                         ending = file[0].split(".")[1]
                     break
             if not microservice:
                 for m in microservices.keys():
-                    if  microservices[m]["servicename"] in file[0].split(".")[0]:
-                        microservice = microservices[m]["servicename"]
+                    if  microservices[m]["name"] in file[0].split(".")[0]:
+                        microservice = microservices[m]["name"]
                         correct_id = m
                         if "." in file[0]:
                             ending = file[0].split(".")[1]

--- a/technology_specific_extractors/spring_encryption/enc_entry.py
+++ b/technology_specific_extractors/spring_encryption/enc_entry.py
@@ -35,7 +35,7 @@ def detect_passwordEncoder(microservices: dict, dfd) -> dict:
             for line in results[r]["content"]:
                 if encoder + ".encode" in line:
                     for m in microservices.keys():
-                        if microservices[m]["servicename"] == microservice:
+                        if microservices[m]["name"] == microservice:
                             if "stereotype_instances" in microservices[m]:
                                 microservices[m]["stereotype_instances"].append("encryption")
                             else:
@@ -64,7 +64,7 @@ def detect_bytesEncryptor(microservices: dict, dfd) -> dict:
                     if password:
                         tagged_values = [("Encrypted String", password)]
             for m in microservices.keys():
-                if microservices[m]["servicename"] == microservice:
+                if microservices[m]["name"] == microservice:
                     if "stereotype_instances" in microservices[m]:
                         microservices[m]["stereotype_instances"] += stereotypes
                     else:
@@ -94,7 +94,7 @@ def detect_keyGenerator(microservices: dict, dfd) -> dict:
                     if "Keygenerator." + command + "().generateKey" in line:
                         microservice = tech_sw.detect_microservice(results[r]["path"], dfd)
                         for m in microservices.keys():
-                            if microservices[m]["servicename"] == microservice:
+                            if microservices[m]["name"] == microservice:
                                 try:
                                     microservices[m]["stereotypes"].append("keygenerator")
                                 except:
@@ -109,7 +109,7 @@ def detect_keyGenerator(microservices: dict, dfd) -> dict:
         for r in results.keys():
             microservice = tech_sw.detect_microservice(results[r]["path"], dfd)
             for m in microservices.keys():
-                if microservices[m]["servicename"] == microservice:
+                if microservices[m]["name"] == microservice:
                     try:
                         microservices[m]["stereotypes"].append("keygenerator")
                     except:

--- a/technology_specific_extractors/spring_gateway/sgt_entry.py
+++ b/technology_specific_extractors/spring_gateway/sgt_entry.py
@@ -14,7 +14,7 @@ def detect_spring_cloud_gateway(microservices: dict, information_flows: dict, ex
         microservice = tech_sw.detect_microservice(results[r]["path"], dfd)
         if microservice:
             for m in microservices.keys():
-                if microservices[m]["servicename"] == microservice:
+                if microservices[m]["name"] == microservice:
                     server = microservice
                     try:
                         microservices[m]["stereotype_instances"].append("gateway")
@@ -42,7 +42,7 @@ def detect_spring_cloud_gateway(microservices: dict, information_flows: dict, ex
         for m2 in microservices.keys():
             for s in microservices[m2]["stereotype_instances"]:
                 if s == "service_discovery":
-                    discovery_server = microservices[m2]["servicename"]
+                    discovery_server = microservices[m2]["name"]
                     break
         if discovery_server:
             for i in information_flows.keys():
@@ -65,7 +65,7 @@ def detect_spring_cloud_gateway(microservices: dict, information_flows: dict, ex
                 target_service = False
                 if prop[0] == "spring_cloud_gateway_route":
                     for m2 in microservices.keys():
-                        if microservices[m2]["servicename"] == prop[1]:
+                        if microservices[m2]["name"] == prop[1]:
                             target_service = prop[1]
                 if target_service:
                     try:

--- a/technology_specific_extractors/spring_oauth/soa_entry.py
+++ b/technology_specific_extractors/spring_oauth/soa_entry.py
@@ -26,7 +26,7 @@ def detect_authorization_server(microservices: dict, dfd) -> dict:
     for r in results.keys():
         authorization_server = tech_sw.detect_microservice(results[r]["path"], dfd)
         for m in microservices.keys():
-            if microservices[m]["servicename"] == authorization_server:
+            if microservices[m]["name"] == authorization_server:
                 if "stereotype_instances" in microservices[m]:
                     microservices[m]["stereotype_instances"].append("authorization_server")
                 else:
@@ -59,7 +59,7 @@ def detect_resource_servers(microservices: dict, dfd) -> dict:
     for r in results.keys():
         resource_server = tech_sw.detect_microservice(results[r]["path"], dfd)
         for m in microservices.keys():
-            if microservices[m]["servicename"] == resource_server:
+            if microservices[m]["name"] == resource_server:
                 try:
                     microservices[m]["stereotype_instances"].append("resource_server")
                 except:
@@ -100,13 +100,13 @@ def detect_token_server(microservices: dict, information_flows: dict, dfd) -> di
                 token_server = fi.resolve_url(token_server_uri, False, dfd)
                 if token_server:
                     for m2 in microservices.keys():
-                        if microservices[m2]["servicename"] == token_server:
+                        if microservices[m2]["name"] == token_server:
                             if "stereotype_instances" in microservices[m2]:
                                 microservices[m2]["stereotype_instances"].append("token_server")
                             else:
                                 microservices[m2]["stereotype_instances"] = ["token_server"]
                             trace = dict()
-                            trace["parent_item"] = microservices[m2]["servicename"]
+                            trace["parent_item"] = microservices[m2]["name"]
                             trace["item"] = "token_server"
                             trace["file"] = prop[2][0]
                             trace["line"] = prop[2][1]
@@ -121,12 +121,12 @@ def detect_token_server(microservices: dict, information_flows: dict, dfd) -> di
                     information_flows[id] = dict()
 
                     information_flows[id]["sender"] = token_server
-                    information_flows[id]["receiver"] = microservices[m]["servicename"]
+                    information_flows[id]["receiver"] = microservices[m]["name"]
                     information_flows[id]["stereotype_instances"] = stereotypes
                     information_flows[id]["tagged_values"] = tagged_values
 
                     trace = dict()
-                    trace["item"] = token_server + " -> " + microservices[m]["servicename"]
+                    trace["item"] = token_server + " -> " + microservices[m]["name"]
                     trace["file"] = prop[2][0]
                     trace["line"] = prop[2][1]
                     trace["span"] = prop[2][2]
@@ -152,7 +152,7 @@ def detect_preauthorized_methods(microservices: dict, dfd) -> dict:
                 tagged_values = [("Pre-authorized Endpoints", endpoints)]
 
             for m in microservices.keys():
-                if microservices[m]["servicename"] == microservice:
+                if microservices[m]["name"] == microservice:
                     try:
                         microservices[m]["stereotype_instances"].append("pre_authorized_endpoints")
                     except:

--- a/technology_specific_extractors/turbine/trb_entry.py
+++ b/technology_specific_extractors/turbine/trb_entry.py
@@ -27,7 +27,7 @@ def detect_turbine_server(microservices: dict, dfd) -> dict:
         for line in results[r]["content"]:
             if "@EnableTurbine" in line:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["stereotype_instances"].append("monitoring_server")
                         except:
@@ -38,7 +38,7 @@ def detect_turbine_server(microservices: dict, dfd) -> dict:
                             microservices[m]["tagged_values"] = [("Monitoring Server", "Turbine")]
 
                         trace = dict()
-                        trace["parent_item"] = microservices[m]["servicename"]
+                        trace["parent_item"] = microservices[m]["name"]
                         trace["item"] = "monitoring_server"
                         trace["file"] = results[r]["path"]
                         trace["line"] = results[r]["line_nr"]
@@ -58,7 +58,7 @@ def detect_turbineamqp(microservices: dict, information_flows: dict, dfd) -> dic
         for line in results[r]["content"]:
             if "@EnableTurbineAmqp" in line:
                 for m in microservices.keys():
-                    if microservices[m]["servicename"] == microservice:
+                    if microservices[m]["name"] == microservice:
                         try:
                             microservices[m]["stereotype_instances"].append("monitoring_server")
                         except:
@@ -69,7 +69,7 @@ def detect_turbineamqp(microservices: dict, information_flows: dict, dfd) -> dic
                             microservices[m]["tagged_values"] = ("Monitoring Server", "Turbine")
 
                         trace = dict()
-                        trace["parent_item"] = microservices[m]["servicename"]
+                        trace["parent_item"] = microservices[m]["name"]
                         trace["item"] = "monitoring_server"
                         trace["file"] = results[r]["path"]
                         trace["line"] = results[r]["line_nr"]
@@ -77,7 +77,7 @@ def detect_turbineamqp(microservices: dict, information_flows: dict, dfd) -> dic
                         traceability.add_trace(trace)
 
                     if ("Monitoring Dashboard", "Hystrix") in microservices[m]["tagged_values"]:
-                        dashboard = microservices[m]["servicename"]
+                        dashboard = microservices[m]["name"]
                         try:
                             id = max(information_flows.keys()) + 1
                         except:
@@ -96,7 +96,7 @@ def detect_turbineamqp(microservices: dict, information_flows: dict, dfd) -> dic
                         traceability.add_trace(trace)
 
                     elif ("Message Broker", "RabbitMQ") in microservices[m]["tagged_values"]:
-                        rabbitmq = microservices[m]["servicename"]
+                        rabbitmq = microservices[m]["name"]
                         try:
                             id = max(information_flows.keys()) + 1
                         except:
@@ -131,8 +131,8 @@ def detect_turbine_stream(microservices: dict, information_flows: dict, dfd) -> 
         for line in results[r]["content"]:
             if "@EnableTurbineStream" in line:
                 for id in microservices.keys():
-                    if microservices[id]["servicename"] == microservice:
-                        turbine_server = microservices[id]["servicename"]
+                    if microservices[id]["name"] == microservice:
+                        turbine_server = microservices[id]["name"]
                         try:
                             microservices[id]["stereotype_instances"].append("monitoring_server")
                         except:
@@ -143,7 +143,7 @@ def detect_turbine_stream(microservices: dict, information_flows: dict, dfd) -> 
                             microservices[id]["tagged_values"] = ("Monitoring Server", "Turbine")
 
                         trace = dict()
-                        trace["parent_item"] = microservices[id]["servicename"]
+                        trace["parent_item"] = microservices[id]["name"]
                         trace["item"] = "monitoring_server"
                         trace["file"] = results[r]["path"]
                         trace["line"] = results[r]["line_nr"]
@@ -178,7 +178,7 @@ def detect_turbine_stream(microservices: dict, information_flows: dict, dfd) -> 
                             dirs.append(os.scandir(local_repo_path + "/" + path))
 
                     if ("Monitoring Dashboard", "Hystrix") in microservices[id]["tagged_values"]:
-                        dashboard = microservices[id]["servicename"]
+                        dashboard = microservices[id]["name"]
                         try:
                             id = max(information_flows.keys()) + 1
                         except:
@@ -199,7 +199,7 @@ def detect_turbine_stream(microservices: dict, information_flows: dict, dfd) -> 
     if turbine_server and uses_rabbit:
         for m in microservices.keys():
             if ("Message Broker", "RabbitMQ") in microservices[m]["tagged_values"]:
-                rabbitmq = microservices[m]["servicename"]
+                rabbitmq = microservices[m]["name"]
                 try:
                     id = max(information_flows.keys()) + 1
                 except:

--- a/technology_specific_extractors/zipkin/zip_entry.py
+++ b/technology_specific_extractors/zipkin/zip_entry.py
@@ -39,12 +39,12 @@ def detect_zipkin_server(microservices: dict, information_flows: dict, iterative
                 parts = zipkin_url.split("/")
                 for m2 in microservices.keys():
                     for part in parts:
-                        if part.split(":")[0] == microservices[m2]["servicename"]:
-                            zipkin_server = microservices[m2]["servicename"]
+                        if part.split(":")[0] == microservices[m2]["name"]:
+                            zipkin_server = microservices[m2]["name"]
                         if not zipkin_server:
                             if (":" in part and
                                 part.split(":")[1] in [b for (a, b, c) in microservices[m2]["properties"] if (a == "port")]):
-                                zipkin_server = microservices[m2]["servicename"]
+                                zipkin_server = microservices[m2]["name"]
                         if zipkin_server:
                             correct_id = m2
                             try:
@@ -52,7 +52,7 @@ def detect_zipkin_server(microservices: dict, information_flows: dict, iterative
                             except:
                                 id = 0
                             information_flows[id] = dict()
-                            information_flows[id]["sender"] = microservices[m]["servicename"]
+                            information_flows[id]["sender"] = microservices[m]["name"]
                             information_flows[id]["receiver"] = zipkin_server
                             information_flows[id]["stereotype_instances"] = ["restful_http"]
                             if tagged_values:
@@ -63,7 +63,7 @@ def detect_zipkin_server(microservices: dict, information_flows: dict, iterative
                                 information_flows[id]["stereotype_instances"].append("load_balanced_link")
 
                             trace = dict()
-                            trace["item"] = microservices[m]["servicename"] + " -> " + zipkin_server
+                            trace["item"] = microservices[m]["name"] + " -> " + zipkin_server
                             trace["file"] = prop[2][0]
                             trace["line"] = prop[2][1]
                             trace["span"] = prop[2][2]
@@ -71,7 +71,7 @@ def detect_zipkin_server(microservices: dict, information_flows: dict, iterative
 
         if not zipkin_server:
             if "openzipkin/zipkin" in microservices[m]["image"]:
-                zipkin_server = microservices[m]["servicename"]
+                zipkin_server = microservices[m]["name"]
                 correct_id = m
 
         if zipkin_server:
@@ -92,7 +92,7 @@ def detect_zipkin_server(microservices: dict, information_flows: dict, iterative
         except:
             id = 0
         microservices[id] = dict()
-        microservices[id]["servicename"] = "zipkin-server"
+        microservices[id]["name"] = "zipkin-server"
         microservices[id]["image"] = "placeholder_image"
         microservices[id]["properties"] = [("port", port, ("file", "line", "span"))]
         microservices[id]["stereotype_instances"] = ["tracing_server"]

--- a/technology_specific_extractors/zookeeper/zoo_entry.py
+++ b/technology_specific_extractors/zookeeper/zoo_entry.py
@@ -10,7 +10,7 @@ def detect_zookeeper(microservices: dict, information_flows: dict, dfd) -> dict:
     # Service
     for m in microservices.keys():
         if "wurstmeister/zookeeper" in microservices[m]["image"]:
-            zookeeper_service = microservices[m]["servicename"]
+            zookeeper_service = microservices[m]["name"]
             try:
                 microservices[m]["stereotype_instances"].append("configuration_server")
             except:
@@ -26,7 +26,7 @@ def detect_zookeeper(microservices: dict, information_flows: dict, dfd) -> dict:
         for m in microservices.keys():
             for prop in microservices[m]["tagged_values"]:
                 if prop == ("Message Broker", "Kafka"):
-                    kafka_service = microservices[m]["servicename"]
+                    kafka_service = microservices[m]["name"]
         if kafka_service:
             try:
                 id = max(information_flows.keys()) + 1

--- a/technology_specific_extractors/zuul/zul_entry.py
+++ b/technology_specific_extractors/zuul/zul_entry.py
@@ -24,7 +24,7 @@ def detect_zuul(microservices: dict, information_flows: dict, external_component
     for r in results.keys():
         zuul_server = tech_sw.detect_microservice(results[r]["path"], dfd)
         for m in microservices.keys():
-            if microservices[m]["servicename"] == zuul_server:    # this is the Zuul server
+            if microservices[m]["name"] == zuul_server:    # this is the Zuul server
                 try:
                     microservices[m]["stereotype_instances"] += ["gateway", "load_balancer"]
                 except:
@@ -49,7 +49,7 @@ def detect_zuul(microservices: dict, information_flows: dict, external_component
                 for m2 in microservices.keys():
                     for s in microservices[m2]["stereotype_instances"]:
                         if s == "service_discovery":
-                            discovery_server = microservices[m2]["servicename"]
+                            discovery_server = microservices[m2]["name"]
                             break
                 if discovery_server:
                     traceability.revert_flow(zuul_server, discovery_server)
@@ -78,13 +78,13 @@ def detect_zuul(microservices: dict, information_flows: dict, external_component
                         if prop[0] == "zuul_route" or prop[0] == "zuul_route_serviceId":
                             for m in microservices.keys():
                                 for part in prop[1].split("/"):
-                                    if microservices[m]["servicename"] in part.casefold():
-                                        receiver = microservices[m]["servicename"]
+                                    if microservices[m]["name"] in part.casefold():
+                                        receiver = microservices[m]["name"]
                         else:
                             for m in microservices.keys():
                                 for part in prop[1].split("://"):
-                                    if microservices[m]["servicename"] in part.split(":")[0].casefold():
-                                        receiver = microservices[m]["servicename"]
+                                    if microservices[m]["name"] in part.split(":")[0].casefold():
+                                        receiver = microservices[m]["name"]
                         if receiver:
                             try:
                                 id = max(information_flows.keys()) + 1


### PR DESCRIPTION
Fixes #8 
Fixes #23
Following changes are implemented:

- Both services and external components now store a field `name`, instead of services having `servicename`, which simplifies parsing of the output/allows to reuse code for service on external components and vice versa
- Merging functions now accept one collection at a time and are called several times in `perform_analysis()` to reduce code duplication (e.g. `merge_service` was called with both services and external components at the same time, but the processing code for each was almost identical and could be reused)
- Issue #8: the reason why `external_component` was duplicated was because this block was concatenating the `type` property; now it skips it https://github.com/tuhh-softsec/code2DFD/blob/f0959c61a649cc3b2de0b6614b0cf8ff88bdeb13/core/dfd_extraction.py#L474-L478 
- Merging functions are simplified, using `itertools` to create all possible pairs for comparison
- Issue #23 : `name`, `sender` and `receiver` fields now have `str.casefold()` applied to them in the merging functions, which removes duplicate services as described in the issue
- `clean_database_connections()` is now applied after merging, since it compares `receiver` to `name`
- As issue #24 shows, there is a chance that a port is something like `3306/tcp`, this is taken into account when merging annotations