### PR TITLE
Fix: off-by-one error in the loop condition

### DIFF
--- a/technology_specific_extractors/http_security/hts_entry.py
+++ b/technology_specific_extractors/http_security/hts_entry.py
@@ -40,7 +40,7 @@ def detect_configurations(dfd):
                             counter = line_nr
                             configuration = line.strip()
 
-                            while not found and counter < len(results[r]["content"]):
+                            while not found and counter < len(results[r]["content"]) - 1:
                                 counter += 1
                                 new_line = results[r]["content"][counter]
                                 new_line = new_line.strip()


### PR DESCRIPTION
Fixes #21 

There was an "off-by-one" error when looping over the list, which results in `ListIndexOutOfRange` error if the list was processed till the end.