### PR TITLE
Use `PyDriller` as git backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,28 @@ The corresponding path only needs to be un-commented for analysis (all others ha
 
 ##### 2. Running the tool
 To start the tool via the terminal using the config file, simply enter `python3 code2DFD.py --config_path PATH_TO_CONFIG` in a command line opened in the root directory.
-For example, `python3 code2DFD.py --config_path config/config.ini` for the example config in this repository.
-The extraction will start and some status messages appear on the screen.
-If you want to analyse in application on GitHub, simply put in the GitHub handle, using the `--github_path` option.
-For example, for the repository `https://github.com/sqshq/piggymetrics`, run the command `python3 code2DFD.py --github_path sqshq/piggymetrics`
+For example, `python3 code2DFD.py --config_path config/config.ini` for the [example config](config/config.ini) in this repository.
 
+The config file needs to specify the following sections and parameters:
+- Repository
+  - `path`: `organization/repository` part of GitHub URL
+  - `url`: the full URL of the repository to clone from (may be local path)
+  - `local_path`: local directory to clone the repository to (without the repository name itself)
+- Technology profiles: same as in [example config](config/config.ini)
+- DFD: empty section
+- Analysis Settings (optional)
+  - `development_mode`: boolean, turns on development mode
+  - `commit`: hash of the commit to checkout and analyze; repository will be returned to the same commit it was in before analysis; if commit not provided, attempts to checkout `HEAD`
+  
+It is possible to provide these parameters also by command line, see `python3 code2DFD.py --help` for exact usage
+
+If both config file and CLI arguments provided, CLI arguments take precedence
+
+###### 2.1 RESTful service
 To run the tool as a RESTful API service, run `python3 flask_code2DFD.py`.
+
 This will spawn up a Flask server and you can trigger DFD-extractions by sending a request to  `localhost:5001/dfd` with parameters `url` and optionally `commit`.
+
 Currently only GitHub URLs are supported this way.
 
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ If you want to analyse in application on GitHub, simply put in the GitHub handle
 For example, for the repository `https://github.com/sqshq/piggymetrics`, run the command `python3 code2DFD.py --github_path sqshq/piggymetrics`
 
 To run the tool as a RESTful API service, run `python3 flask_code2DFD.py`.
-This will spawn up a Flask server and you can trigger DFD-extractions by sending a request to or opening your browser at `localhost:5000/dfd?path=*repository/path*`
+This will spawn up a Flask server and you can trigger DFD-extractions by sending a request to  `localhost:5001/dfd` with parameters `url` and optionally `commit`.
+Currently only GitHub URLs are supported this way.
 
 
 ##### 3. Output

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -98,9 +98,13 @@ def main():
     repository = Repository(path_to_repo=local_path)
     with repository._prep_repo(local_path) as git_repo:
         commit = head = git_repo.get_head().hash[:7]
-        if args.commit is not None: # TODO should get commit from config file as well
+        if args.commit is not None:
             commit = args.commit[:7]
-            git_repo.checkout(commit)
+            tmp.tmp_config.set("Analysis Settings", "commit", args.commit)
+        elif tmp.tmp_config.has_option("Analysis Settings", "commit"):
+            commit = tmp.tmp_config.get("Analysis Settings", "commit")[:7]
+            tmp.tmp_config.set("Analysis Settings", "commit", commit)
+        git_repo.checkout(commit)
         tmp.tmp_config.set("Analysis Settings", "output_path", get_output_path(repo_path, commit))
         print(f"Analyzing repository {repo_path} at commit {commit}")
         dfd_extraction.perform_analysis()

--- a/code2DFD.py
+++ b/code2DFD.py
@@ -101,7 +101,7 @@ def main():
         if args.commit is not None: # TODO should get commit from config file as well
             commit = args.commit[:7]
             git_repo.checkout(commit)
-        tmp.tmp_config.set("Analysis Settings", "output_path", get_output_path(repo_path, commit)) #TODO output generators should put correct paths
+        tmp.tmp_config.set("Analysis Settings", "output_path", get_output_path(repo_path, commit))
         print(f"Analyzing repository {repo_path} at commit {commit}")
         dfd_extraction.perform_analysis()
         git_repo.checkout(head)

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,29 +1,28 @@
 [Repository]
-path = apssouza22/java-microservice
 url = https://github.com/apssouza22/java-microservice
-;path = callistaenterprise/blog-microservices
-;path = fernandoabcampos/spring-netflix-oss-microservices
-;path = georgwittberger/apache-spring-boot-microservice-example
-;path = mudigal-technologies/microservices-sample
-;path = spring-petclinic/spring-petclinic-microservices
-;path = sqshq/piggymetrics
-
-;path = anilallewar/microservices-basics-spring-boot
-;path = ewolff/microservice
-;path = ewolff/microservice-kafka
-;path = jferrater/tap-and-eat-microservices
-;path = koushikkothagal/spring-boot-microservices-workshop
-;path = mdeket/spring-cloud-movie-recommendation
-;path = blaugmail/clone-sample-spring-oauth2-microservices
-;path = shabbirdwd53/springboot-microservice
-;path = rohitghatol/spring-boot-microservices
-;path = yidongnan/spring-cloud-netflix-example
+;url = https://github.com/callistaenterprise/blog-microservices
+;url = https://github.com/fernandoabcampos/spring-netflix-oss-microservices
+;url = https://github.com/georgwittberger/apache-spring-boot-microservice-example
+;url = https://github.com/mudigal-technologies/microservices-sample
+;url = https://github.com/spring-petclinic/spring-petclinic-microservices
+;url = https://github.com/sqshq/piggymetrics
+;url = https://github.com/anilallewar/microservices-basics-spring-boot
+;url = https://github.com/ewolff/microservice
+;url = https://github.com/ewolff/microservice-kafka
+;url = https://github.com/jferrater/tap-and-eat-microservices
+;url = https://github.com/koushikkothagal/spring-boot-microservices-workshop
+;url = https://github.com/mdeket/spring-cloud-movie-recommendation
+;url = https://github.com/blaugmail/clone-sample-spring-oauth2-microservices
+;url = https://github.com/shabbirdwd53/springboot-microservice
+;url = https://github.com/rohitghatol/spring-boot-microservices
+;url = https://github.com/yidongnan/spring-cloud-netflix-example
 
 [Technology Profiles]
 communication_techs_list = [("RabbitMQ", "rmq"), ("Kafka", "kfk"), ("RestTemplate", "rst"), ("FeignClient", "fgn"), ("Implicit Connections", "imp"), ("Database Connections", "dbc"), ("HTML", "html"), ("Docker-Compose", "dcm")]
 
 [Analysis Settings]
 development_mode = False
-commit = 056414c4c938e536f467a3f37532194b860d96a3
+; commit for apssouza22/java-microservice
+;commit = 056414c4c938e536f467a3f37532194b860d96a3
 
 [DFD]

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,5 +1,6 @@
 [Repository]
 path = apssouza22/java-microservice
+url = https://github.com/apssouza22/java-microservice
 ;path = callistaenterprise/blog-microservices
 ;path = fernandoabcampos/spring-netflix-oss-microservices
 ;path = georgwittberger/apache-spring-boot-microservice-example

--- a/config/config.ini
+++ b/config/config.ini
@@ -23,5 +23,6 @@ communication_techs_list = [("RabbitMQ", "rmq"), ("Kafka", "kfk"), ("RestTemplat
 
 [Analysis Settings]
 development_mode = False
+commit = 056414c4c938e536f467a3f37532194b860d96a3
 
 [DFD]

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -57,7 +57,6 @@ def perform_analysis():
     """
     local_path = tmp.tmp_config.get("Repository", "local_path")
     url_path = tmp.tmp_config.get("Repository", "url")
-    repo_path = tmp.tmp_config.get("Repository", "path")
 
     os.makedirs(local_path, exist_ok=True)
     repository = Repository(path_to_repo=url_path, clone_repo_to=local_path)
@@ -68,10 +67,10 @@ def perform_analysis():
             commit = tmp.tmp_config.get("Analysis Settings", "commit")
         else:
             commit = head
-        tmp.tmp_config.set("Analysis Settings", "output_path", os.path.join(os.getcwd(), "code2DFD_output", repo_path.replace("/", "--"), commit))
+        repo_name = git_repo.project_name
+        tmp.tmp_config.set("Analysis Settings", "output_path", os.path.join(os.getcwd(), "code2DFD_output", repo_name.replace("/", "--"), commit))
         git_repo.checkout(commit)
-
-        print(f"\nStart extraction of DFD for {repo_path} on commit {commit} at {datetime.now().strftime("%H:%M:%S")}")
+        print(f"\nStart extraction of DFD for {repo_name} on commit {commit} at {datetime.now().strftime("%H:%M:%S")}")
         codeable_models, traceability_content = DFD_extraction()
         print(f"Finished: {datetime.now().strftime("%H:%M:%S")}")
 

--- a/core/dfd_extraction.py
+++ b/core/dfd_extraction.py
@@ -1,6 +1,9 @@
 import ast
 from datetime import datetime
 from itertools import combinations
+import os
+
+from pydriller import Repository
 
 import output_generators.codeable_model as codeable_model
 import core.technology_switch as tech_sw
@@ -49,14 +52,38 @@ from core.DFD import CDFD
 
 
 def perform_analysis():
+    """
+    Entrypoint for the DFD extraction that initializes the repository
+    """
+    local_path = tmp.tmp_config.get("Repository", "local_path")
+    url_path = tmp.tmp_config.get("Repository", "url")
+    repo_path = tmp.tmp_config.get("Repository", "path")
+
+    os.makedirs(local_path, exist_ok=True)
+    repository = Repository(path_to_repo=url_path, clone_repo_to=local_path)
+    with repository._prep_repo(url_path) as git_repo:
+        tmp.tmp_config.set("Repository", "local_path", str(git_repo.path))
+        head = git_repo.get_head().hash[:7]
+        if tmp.tmp_config.has_option("Analysis Settings", "commit"):
+            commit = tmp.tmp_config.get("Analysis Settings", "commit")
+        else:
+            commit = head
+        tmp.tmp_config.set("Analysis Settings", "output_path", os.path.join(os.getcwd(), "code2DFD_output", repo_path.replace("/", "--"), commit))
+        git_repo.checkout(commit)
+
+        print(f"\nStart extraction of DFD for {repo_path} on commit {commit} at {datetime.now().strftime("%H:%M:%S")}")
+        codeable_models, traceability_content = DFD_extraction()
+        print(f"Finished: {datetime.now().strftime("%H:%M:%S")}")
+
+        git_repo.checkout(head)
+
+    return codeable_models, traceability_content
+
+
+def DFD_extraction():
     """Main function for the extraction, calling all technology-specific extractors, managing output etc.
     """
-
     dfd = CDFD("TestDFD")
-    repo_path = tmp.tmp_config["Repository"]["path"]
-    now = datetime.now()
-    start_time = now.strftime("%H:%M:%S")
-    print("\n\tStart extraction of DFD for " + repo_path + " at " + str(start_time))
 
     microservices, information_flows, external_components = dict(), dict(), dict()
 

--- a/core/file_interaction.py
+++ b/core/file_interaction.py
@@ -28,11 +28,6 @@ def get_output_path(repo_path: str, commit: str = None) -> str:
     else:
         return os.path.join(os.getcwd(), 'code2DFD_output', repo_path, commit)
 
-
-def get_local_path(repo_path: str) -> str:
-    return os.path.join(os.getcwd(), "analysed_repositories", *repo_path.split("/")[1:])
-
-
 def clone_repo(repo_path, local_path):
     # Create analysed_repositories folder in case it doesn't exist yet (issue #2)
     os.makedirs(os.path.join(os.getcwd(), "analysed_repositories"), exist_ok=True)

--- a/core/file_interaction.py
+++ b/core/file_interaction.py
@@ -21,35 +21,6 @@ repo_cache = dict()
 exception_counter_repo = 0
 
 
-def get_output_path(repo_path: str, commit: str = None) -> str:
-    repo_path = repo_path.replace("/", "--")
-    if commit is None:
-        return os.path.join(os.getcwd(), 'code2DFD_output', repo_path)
-    else:
-        return os.path.join(os.getcwd(), 'code2DFD_output', repo_path, commit)
-
-def clone_repo(repo_path, local_path):
-    # Create analysed_repositories folder in case it doesn't exist yet (issue #2)
-    os.makedirs(os.path.join(os.getcwd(), "analysed_repositories"), exist_ok=True)
-    if not repo_downloaded(local_path):
-        download_repo(repo_path, local_path)
-
-
-def repo_downloaded(repo_folder: str) -> bool:
-    """Checks if repository has been downloaded from GitHub already.
-    """
-
-    return os.path.isdir(repo_folder)
-
-
-def download_repo(repo_path: str, local_path: str):
-    """Downloads repository from GitHub for local querying.
-    """
-
-    command = f"git clone https://github.com/{repo_path}.git {local_path}"
-    os.system(command)
-
-
 def detection_comment(file_name, line):
     """Checks if provided line is a comment. Based on language of the file, so only works for the ones with specified comment-delimiters.
     """
@@ -92,13 +63,9 @@ def search_keywords(keywords: str):
     """Searches keywords locally using grep.
     """
 
-    repo_path = tmp.tmp_config["Repository"]["path"]
     repo_folder = tmp.tmp_config["Repository"]["local_path"]
 
     results = dict()
-
-    if not repo_downloaded(repo_folder):
-        download_repo(repo_path, repo_folder)
 
     if isinstance(keywords, str):
         keywords = [keywords]
@@ -422,7 +389,7 @@ def file_exists(file_name: str) -> bool:
     return False
 
 
-def get_repo_contents_local(repo_path: str, path: str) -> set:
+def get_repo_contents_local(path: str) -> set:
     """Creates a set of all files in the repository given as path.
     """
 
@@ -430,9 +397,6 @@ def get_repo_contents_local(repo_path: str, path: str) -> set:
 
     local_repo_path = tmp.tmp_config["Repository"]["local_path"]
     to_crawl = local_repo_path
-
-    if not repo_downloaded(local_repo_path):
-        download_repo(repo_path, local_repo_path)
 
     if path:
         to_crawl = os.path.join(local_repo_path, path)

--- a/core/file_interaction.py
+++ b/core/file_interaction.py
@@ -21,9 +21,12 @@ repo_cache = dict()
 exception_counter_repo = 0
 
 
-def get_output_path(repo_path: str) -> str:
+def get_output_path(repo_path: str, commit: str = None) -> str:
     repo_path = repo_path.replace("/", "--")
-    return os.path.join(os.getcwd(), 'code2DFD_output', repo_path)
+    if commit is None:
+        return os.path.join(os.getcwd(), 'code2DFD_output', repo_path)
+    else:
+        return os.path.join(os.getcwd(), 'code2DFD_output', repo_path, commit)
 
 
 def get_local_path(repo_path: str) -> str:

--- a/flask_code2DFD.py
+++ b/flask_code2DFD.py
@@ -4,42 +4,33 @@ import code2DFD
 
 app = Flask(__name__, instance_relative_config = True)
 
-# Create default endpoint
+
 @app.get('/')
 def index():
-    index_message = "API for DFD extraction. \
+    index_message = ("API for DFD extraction. \
     Provide a GitHub URL to endpoint /dfd as parameter \"url\" to receive the extracted DFD: \
     /dfd?url=https://github.com/georgwittberger/apache-spring-boot \
-           -microservice-example"
+           -microservice-example; \
+                     Optionally provide a commit hash as \"commit\" parameter")
 
     return index_message
 
 
-# Create endpoint /dfd
 @app.get('/dfd')
 def dfd():
 
-    # Retrieve argument 'path' from request
     url = request.args.get("url")
+    commit = request.args.get("commit", None)
 
     if not url:
         return "Please specify a URL, e.g. /dfd?url=https://github.com/georgwittberger/apache-spring-boot" \
                "-microservice-example "
-    try:
-        path = url.split("github.com/")[1]
-    except:
-        return "Please specify the complete URL, e.g. /dfd?url=https://github.com/georgwittberger/apache-spring-boot" \
-               "-microservice-example "
 
     # Call Code2DFD
-    results = code2DFD.api_invocation(path)
+    results = code2DFD.api_invocation(url, commit)
 
     # Create response JSON object and return it
-    response = jsonify(
-        codeable_models_file = results["codeable_models_file"],
-        traceability_file = results["traceability"],
-        execution_time = results["execution_time"]
-    )
+    response = jsonify(**results)
 
     return response
 

--- a/output_generators/codeable_model.py
+++ b/output_generators/codeable_model.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import tmp.tmp as tmp
 
@@ -8,7 +9,8 @@ import tmp.tmp as tmp
 def output_codeable_model(microservices, information_flows, external_components):
     """Entry function to creation of codeable models. Calls all necessary helper functions and outputs the codeable model"""
 
-    model_name = tmp.tmp_config["Repository"]["path"].split("/")[-1]
+    parts = Path(tmp.tmp_config["Analysis Settings"]["output_path"]).parts
+    model_name = f"{parts[-2]}_{parts[-1]}"
 
     file_content = header()
     file_content += "\"" + str(model_name) + "\""

--- a/output_generators/codeable_models_to_plantuml.py
+++ b/output_generators/codeable_models_to_plantuml.py
@@ -1,4 +1,5 @@
 import os.path
+from pathlib import Path
 
 import tmp.tmp as tmp
 
@@ -13,7 +14,8 @@ def convert(codeable_models_path: str) -> str:
     global plantuml_new
 
     output_file_path = tmp.tmp_config["Analysis Settings"]["output_path"]
-    filename = f"{os.path.split(output_file_path)[1]}_uml.txt"
+    parts = Path(output_file_path).parts
+    filename = f"{parts[-2]}--{parts[-1]}_uml.txt"
     output_file_path = os.path.join(output_file_path, filename)
 
     add_header()

--- a/output_generators/json_architecture.py
+++ b/output_generators/json_architecture.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import tmp.tmp as tmp
 
@@ -13,7 +14,8 @@ def generate_json_architecture(microservices: dict, information_flows: dict, ext
                  "external_components": list(external_components.values())}
     
     output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
-    filename = f"{os.path.split(output_path)[1]}_json_architecture.json"
+    parts = Path(output_path).parts
+    filename = f"{parts[-2]}--{parts[-1]}_json_architecture.json"
     output_path = os.path.join(output_path, filename)
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/output_generators/json_edges.py
+++ b/output_generators/json_edges.py
@@ -5,6 +5,7 @@ This was needed for another project using Code2DFD and will remain here for now 
 
 import json
 import os
+from pathlib import Path
 
 import tmp.tmp as tmp
 
@@ -33,7 +34,8 @@ def write_to_file(architecture_dict):
     """
 
     output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
-    filename = f"{os.path.split(output_path)[1]}_edges.json"
+    parts = Path(output_path).parts
+    filename = f"{parts[-2]}--{parts[-1]}_edges.json"
     output_path = os.path.join(output_path, filename)
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/output_generators/plaintext.py
+++ b/output_generators/plaintext.py
@@ -1,11 +1,13 @@
 import os
+from pathlib import Path
 
 import tmp.tmp as tmp
 
 
 def write_plaintext(microservices, information_flows, external_components):
     output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
-    filename = f"{os.path.split(output_path)[1]}_results.txt"
+    parts = Path(output_path).parts
+    filename = f"{parts[-2]}--{parts[-1]}_results.txt"
     output_path = os.path.join(output_path, filename)
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
     with open(output_path, "w") as output_file:

--- a/output_generators/traceability.py
+++ b/output_generators/traceability.py
@@ -36,9 +36,7 @@ def add_trace(traceability_info: dict):
         else:
 
             # Adding the highlighting of the lines to the link (GitHub's feature)
-            url = convert_path_to_url(traceability_info["file"])
-            if not "implicit" in url and not "heuristic" in url:
-                url = url + "#L" + str(traceability_info["line"])
+            file = traceability_info["file"]
 
             item = traceability_info["item"]
             parent_item = traceability_info["parent_item"]
@@ -51,28 +49,26 @@ def add_trace(traceability_info: dict):
             for sub_item in traceability[type][parent_item]["sub_items"].keys():
                 if sub_item == traceability_info["item"]:
                     exists = True
-                    if (traceability[type][parent_item]["sub_items"][sub_item]["file"] != url or
+                    if (traceability[type][parent_item]["sub_items"][sub_item]["file"] != file or
                             traceability[type][parent_item]["sub_items"][sub_item]["line"] != traceability_info["line"] or
                             traceability[type][parent_item]["sub_items"][sub_item]["span"] != str(traceability_info["span"])):
 
                         traceability[type][parent_item]["sub_items"][item] = dict()
-                        traceability[type][parent_item]["sub_items"][item]["file"] = url
+                        traceability[type][parent_item]["sub_items"][item]["file"] = file
                         traceability[type][parent_item]["sub_items"][item]["line"] = traceability_info["line"]
                         traceability[type][parent_item]["sub_items"][item]["span"] = str(traceability_info["span"])
 
             # sub item does not exist yet
             if not exists:
                 traceability[type][parent_item]["sub_items"][item] = dict()
-                traceability[type][parent_item]["sub_items"][item]["file"] = url
+                traceability[type][parent_item]["sub_items"][item]["file"] = file
                 traceability[type][parent_item]["sub_items"][item]["line"] = traceability_info["line"]
                 traceability[type][parent_item]["sub_items"][item]["span"] = str(traceability_info["span"])
 
 
     else:
         # Adding the highlighting of the lines to the link (GitHub's feature)
-        url = convert_path_to_url(traceability_info["file"])
-        if not "implicit" in url and not "heuristic" in url:
-            url = url + "#L" + str(traceability_info["line"])
+        file = traceability_info["file"]
 
         # check, whether item is already in dict
         exists = False
@@ -85,13 +81,13 @@ def add_trace(traceability_info: dict):
         for item in traceability[type].keys():
             if item == traceability_info["item"]:
                 exists = True
-                if (not traceability[type][item]["file"] == url
+                if (not traceability[type][item]["file"] == file
                     or not traceability[type][item]["line"] == traceability_info["line"]
                     or not traceability[type][item]["span"] == str(traceability_info["span"])):
 
                     item = traceability_info["item"]
                     traceability[type][item] = dict()
-                    traceability[type][item]["file"] = url
+                    traceability[type][item]["file"] = file
                     traceability[type][item]["line"] = traceability_info["line"]
                     traceability[type][item]["span"] = str(traceability_info["span"])
                 break
@@ -100,7 +96,7 @@ def add_trace(traceability_info: dict):
         if not exists:
             item = traceability_info["item"]
             traceability[type][item] = dict()
-            traceability[type][item]["file"] = url
+            traceability[type][item]["file"] = file
             traceability[type][item]["line"] = traceability_info["line"]
             traceability[type][item]["span"] = str(traceability_info["span"])
 
@@ -123,19 +119,6 @@ def revert_flow(old_sender: str, old_receiver: str):
 
     if to_delete:
         del traceability["edges"][to_delete]
-
-
-def convert_path_to_url(path: str) -> str:
-    """ Resolves the passed path to the corresponding GitHub download url.
-    """
-
-    if "implicit" in path or "heuristic" in path:
-        return path
-
-    repo_path = tmp.tmp_config["Repository"]["path"]
-    url = "https://github.com/" + str(repo_path) + "/blob/master/" + str(path)
-
-    return url
 
 
 def output_traceability():

--- a/output_generators/traceability.py
+++ b/output_generators/traceability.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 
 import tmp.tmp as tmp
 
@@ -171,7 +172,8 @@ def write_to_file():
     """
 
     output_path = tmp.tmp_config["Analysis Settings"]["output_path"]
-    filename = f"{os.path.split(output_path)[1]}_traceability.json"
+    parts = Path(output_path).parts
+    filename = f"{parts[-2]}--{parts[-1]}_traceability.json"
     output_path = os.path.join(output_path, filename)
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ plantuml==0.3.0
 PyYAML==6.0
 requests==2.26.0
 ruamel.base==1.0.0
+PyDriller==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 Flask==2.1.2
 plantuml==0.3.0
 PyYAML==6.0
-requests==2.26.0
 ruamel.base==1.0.0
 PyDriller==2.6.0

--- a/technology_specific_extractors/docker/dcr_entry.py
+++ b/technology_specific_extractors/docker/dcr_entry.py
@@ -1,6 +1,5 @@
 import os
 
-import core.file_interaction as fi
 import tmp.tmp as tmp
 
 
@@ -29,18 +28,3 @@ def detect_port(path: str) -> int:
                 dirs.append(os.scandir(entry.path))
 
     return port
-
-
-def extract_port(download_url: str):
-    """Looks for exposed port in dockerfile.
-    """
-
-    try:
-        file = fi.file_as_lines(download_url)
-        for line in file:
-            line = line.casefold()
-            if "expose" in line:
-                port = line.split("expose")[1].split("/")[0].strip()
-                return port
-    except:
-        return False

--- a/technology_specific_extractors/spring_config/cnf_entry.py
+++ b/technology_specific_extractors/spring_config/cnf_entry.py
@@ -220,13 +220,11 @@ def parse_config_files(config_server: str, config_file_path: str, config_file_pa
 
     if config_file_path:
         new_contents = fi.get_repo_contents_local(config_file_path)
-        for file in new_contents:
-            contents.add(file)
+        contents.update(new_contents)
 
     else:
         new_contents = fi.get_repo_contents_local(False)
-        for file in new_contents:
-            contents.add(file)
+        contents.update(new_contents)
 
     # external (other github repository) didn't work, look locally
     if config_file_path_local:
@@ -235,18 +233,16 @@ def parse_config_files(config_server: str, config_file_path: str, config_file_pa
         config_file_path_local = os.path.relpath(config_file_path_local, start=local_path)
 
         new_contents = fi.get_repo_contents_local(config_file_path_local)
-        for file in new_contents:
-            contents.add(file)
+        contents.update(new_contents)
 
 
     if not gh_contents and not contents:
         new_contents = fi.get_repo_contents_local(config_file_path)
-        for file in new_contents:
-            contents.add(file)
+        contents.update(new_contents)
 
     if gh_contents:
         for file in gh_contents:
-            contents.add((file.name, file.download_url, file.path))
+            contents.add((file.name, file.path))
 
     if contents:
         for file in contents:
@@ -271,7 +267,7 @@ def parse_config_files(config_server: str, config_file_path: str, config_file_pa
             if microservice:
                 if ending:
                     if ending == "yml" or ending == "yaml":
-                        name, properties = parse.parse_yaml_file(file[1], file[2])
+                        name, properties = parse.parse_yaml_file(file[1])
                         name = name[0]
                     elif ending == "properties":
                         name, properties = parse.parse_properties_file(file[1])

--- a/technology_specific_extractors/spring_config/cnf_entry.py
+++ b/technology_specific_extractors/spring_config/cnf_entry.py
@@ -215,19 +215,16 @@ def parse_config_files(config_server: str, config_file_path: str, config_file_pa
         config_file_path = ""
     if config_repo_uri:
         information_flows, external_components = set_repo(information_flows, external_components, config_repo_uri, config_server)
-        repo_path = config_repo_uri.split("github.com/")[1].split(".")[0]
-    else:
-        repo_path = tmp.tmp_config["Repository"]["path"]
     gh_contents = False
     contents = set()
 
     if config_file_path:
-        new_contents = fi.get_repo_contents_local(repo_path, config_file_path)
+        new_contents = fi.get_repo_contents_local(config_file_path)
         for file in new_contents:
             contents.add(file)
 
     else:
-        new_contents = fi.get_repo_contents_local(repo_path, False)
+        new_contents = fi.get_repo_contents_local(False)
         for file in new_contents:
             contents.add(file)
 
@@ -237,15 +234,13 @@ def parse_config_files(config_server: str, config_file_path: str, config_file_pa
         local_path = tmp.tmp_config["Repository"]["local_path"]
         config_file_path_local = os.path.relpath(config_file_path_local, start=local_path)
 
-        new_contents = fi.get_repo_contents_local(repo_path, config_file_path_local)
+        new_contents = fi.get_repo_contents_local(config_file_path_local)
         for file in new_contents:
             contents.add(file)
 
 
     if not gh_contents and not contents:
-        repo_path = tmp.tmp_config["Repository"]["path"]
-
-        new_contents = fi.get_repo_contents_local(repo_path, config_file_path)
+        new_contents = fi.get_repo_contents_local(config_file_path)
         for file in new_contents:
             contents.add(file)
 


### PR DESCRIPTION
Changes in the current PR:

- `code2DFD.py` file now only initializes values into the `ConfigParser` object (also in the Flask case), the actual setup of the repository is performed in `dfd_extraction.perform_analysis()`, which internally calls `ddd_extraction.DFD_extraction()` to perform the actual analysis.
- `PyDriller` library is used to handle git repositories, which allows to support more than just GitHub urls. Own functions for handling the repository are removed. Library is added to `requirements.txt`.
    - In particular, it is possible now to provide in cli/config/flask call a specific commit which will be checked out to analyze.
- The analysis was coupled to GitHub because in many places in the code a GitHub download URL was constructed, which was later deconstructed in another function to get again the local path. This is now removed, all functions now pass local paths (or paths relative to `local_path` of the repo).
    - Because of this, `requests` is now longer a direct dependency and is removed from `requirements.txt`
    - Also, traceability now reports the file path, not GitHub URL.
- Because of two previous points, `repo_path` option is no longer necessary and is replaced by `repo_url`. The example config is updated accordingly.
- In the extractor `docker/dcr_entry.py` the unused `extract_port()` function is removed since `detect_port()` from the same file is used everywhere
- `zuul()` function in `implicit_connections/imp_entry.py` seemed to contain some dead code that referenced things that are not found in the current codebase (`repo = fi.get_repo(); repo.get_contents()`). It is now changed to reflect how it is supposed to work according to my understanding of existing code.

PS I had some issues with installing Flask to a virtual environment, so I could not test my changes. It would be good if you could confirm that also the updated Flask code works.